### PR TITLE
Update batocera-resolution-v38_MYZAR_ZFEbHVUE

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v38_MYZAR_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v38_MYZAR_ZFEbHVUE
@@ -131,16 +131,16 @@ case "${ACTION}" in
 	xrandr --listModes | sed -e s+'\*$'++ | sed -e s+'^\([^ ]*\) \(.*\)$'+'\1:\2'+ | sed -e "/\b\(SR\)\b/d"
 	;;
     "setMode")
-	MODE=$1
-	read WIDTH HEIGHT PARTHZ <<< $(echo $MODE | awk -F'[x.]' '{print $1, $2, $3 "." $4}')
-	switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}:${PARTHZ} 
+    MODE=$1
+    read WIDTH HEIGHT PARTHZ <<< $(echo $MODE | awk -F'[x.]' '{print $1, $2, $3 "." $4}')
+    switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -f ${WIDTH}x${HEIGHT}@${PARTHZ} -s -k
 
 	;;
     "defineMode")   
 	MODE=$1
 	read WIDTH HEIGHT PARTHZ <<< $(echo $MODE | awk -F'[x.]' '{print $1, $2, $3 "." $4}')
 	RES_MODE="${WIDTH}x${HEIGHT}"
-	MODE_xrandr=$(switchres  ${WIDTH} ${HEIGHT} ${PARTHZ} -f ${WIDTH}x${HEIGHT}:${PARTHZ}) #> /dev/null 2>/dev/null
+	MODE_switchres=$(switchres  ${WIDTH} ${HEIGHT} ${PARTHZ} -f ${WIDTH}x${HEIGHT}@${PARTHZ}) #> /dev/null 2>/dev/null
 	MODELINE_CUSTOM=$(echo "$MODE_xrandr" | sed -n 's/.*Modeline "[^"]*" \([0-9.]\+\) \([0-9 ]\+\) \(.*\)/\1 \2 \3/p')
 	OUTPUT=$(xrandr --listConnectedOutputs | grep -E '\*$' | sed -e s+'*$'++ | head -1)
        	xrandr -display :0.0 --newmode ${RES_MODE} ${MODELINE_CUSTOM}


### PR DESCRIPTION
Fixes wrong formatting for how switchres forces resolution switching...

Example
From
`switchres 384 240 60.00 -s -k -f 384x240:60.00`
To
`switchres 384 240 60.00 -f 384x240@60.00 -s -k`

_As described here from the switchres wiki page / manual pages_
`-f, --force <w>x<h>@<r>`           Force a specific video mode from display mode list

@ZFEbHVUE Also spotted the issue in "defineMode")