### PR TITLE
first_script.sh, delete, flush sr modes on exit

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v33
+++ b/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v33
@@ -49,6 +49,10 @@ case $1 in
     	;;
     	gameStop)
 
+		#Delete/flush out switchres generated resolution on game exit. 
+		xrandr --listModes | grep 'SR-1_' | awk '{print $2}' | while read -r mode; do
+		xrandr --delmode [card_display] "$mode"		
+
 		xrandr -display :0.0 -o [display_ES_rotation]
 		xrandr -display :0.0 --output [card_display] --set TearFree OFF
 		xrandr -display :0.0 --output [card_display] --mode "[es_resolution]"


### PR DESCRIPTION
Delete / flush out switchres generated resolution on game exit.  
These would be normally be deleted upon a reboot or if you restart the x server.