### PR TITLE
Update first_script.sh-generic-v33-for Mame with ESin SR resolution.

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v33
+++ b/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v33
@@ -27,6 +27,13 @@ case $1 in
 
 		elif [[ "$3" == "mame" ]]; then
 
+			#MYZAR
+			#batocera-resolution setMode 640x480.60.00
+
+			#ZFEbHVUE
+                        batocera-resolution defineMode "640x480.60.0"
+	       	        batocera-resolution setMode_CVT "640x480.60.0"
+
 			xrandr -display :0.0 -o [display_mame_rotation]
 
 		elif [[ "$3" == "fpinball" ]]; then


### PR DESCRIPTION
Here we start mame with 640x480 other was if ES is in 1280x480 the dimensions of mame will be not good with a game using for example  SR-1_1280x240@60.00  60.00* ( for Intel with VGA)

two solution using MYZAR setMode Or ZFEbHVUE definemode are good