### PR TITLE
AMD R9 380 Freeze bug fix for ES

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/R9/es_settings.cfg
+++ b/userdata/system/Batocera-CRT-Script/System_configs/R9/es_settings.cfg
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config>
+	<string name="GameTransitionStyle" value="instant" />
+	<string name="ShowFlags" value="auto" />
+	<string name="ThemeSet" value="es-theme-carbon" />
+</config>


### PR DESCRIPTION
Will solve this.. 

Known freezing issue with AMD R9 cards in Emulation Station. Set Game Launch Transition to Instant Main Menu->User Interface Settings->Game Launch Transition-> Instant First part of update.

Next update will be adding additional code for modifying the emulationstation configuration file only when the graphics card is identified as an ATI R9 380/380x.