### PR TITLE
Update first_script.sh-generic-v33

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v33
+++ b/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v33
@@ -57,8 +57,8 @@ case $1 in
     	gameStop)
 
 		#Delete/flush out switchres generated resolution on game exit. 
-		xrandr --listModes | grep 'SR-1_' | awk '{print $2}' | while read -r mode; do
-		xrandr --delmode [card_display] "$mode"		
+		#xrandr --listModes | grep 'SR-1_' | awk '{print $2}' | while read -r mode; do
+		#xrandr --delmode [card_display] "$mode"		
 
 		xrandr -display :0.0 -o [display_ES_rotation]
 		xrandr -display :0.0 --output [card_display] --set TearFree OFF


### PR DESCRIPTION
Please Daniel
I put away that things:

xrandr --listModes | grep 'SR-1_' | awk '{print $2}' | while read -r mode; do
xrandr --delmode VGA-1 "$mode"		

No right in term of coding. It gave mistake implementation;

first_script didn't work because of that.
