### PR TITLE
Add vnc server installer to crt tools, part 2

### DIFF
--- a/userdata/system/Batocera-CRT-Script/vnc/crt/Install_vnc_server.sh
+++ b/userdata/system/Batocera-CRT-Script/vnc/crt/Install_vnc_server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+DISPLAY=:0.0 xterm -fs 15 -maximized -fg white -bg black -fa "DejaVuSansMono" -en UTF-8 -e bash -c "DISPLAY=:0.0  /userdata/system/Batocera-CRT-Script/vnc_server_install.sh"

--- a/userdata/system/Batocera-CRT-Script/vnc/vnc_server_install.sh
+++ b/userdata/system/Batocera-CRT-Script/vnc/vnc_server_install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Check if dialog package is installed
+if ! command -v dialog &> /dev/null; then
+    echo "Error: dialog package is not installed. Please install it."
+    exit 1
+fi
+
+# Function to download files and display progress
+download_file() {
+    URL=$1
+    DEST=$2
+    wget --progress=bar:force -O "$DEST" "$URL" 2>&1 | \
+        dialog --backtitle "Downloading Files" --title "Download Progress" --gauge "Downloading $DEST" 10 70
+}
+
+# Function to display a message box
+msgbox() {
+    dialog --backtitle "Downloading Files" --title "Message" --msgbox "$1" 8 50
+}
+
+# Downloading the files directly to /lib & /usr/lib
+download_file "https://archive.org/download/install-vnc_server_batocera/libcrypt.so.1" "/lib/libcrypt.so.1"
+download_file "https://archive.org/download/install-vnc_server_batocera/libcrypt.so.1" "/usr/lib/libcrypt.so.1"
+download_file "https://archive.org/download/install-vnc_server_batocera/libvncclient.so.1" "/usr/lib/libvncclient.so.1"
+download_file "https://archive.org/download/install-vnc_server_batocera/libvncserver.so.1" "/usr/lib/libvncserver.so.1"
+download_file "https://archive.org/download/install-vnc_server_batocera/libsasl2.so.2" "/usr/lib/libsasl2.so.2"
+
+# Downloading the vnc binary directly to /usr/bin and granting execution permissions
+download_file "https://archive.org/download/install-vnc_server_batocera/vnc" "/usr/bin/vnc"
+chmod +x /usr/bin/vnc
+
+# Downloading the vnc binary directly to /usr/bin and granting execution permissions
+download_file "https://archive.org/download/install-vnc_server_batocera/x11vnc" "/usr/bin/x11vnc"
+chmod +x /usr/bin/x11vnc
+
+# Save overlay
+batocera-save-overlay
+
+# Display message
+msgbox "Files downloaded and configured successfully. Please Reboot"
+
+# Clear the terminal
+clear


### PR DESCRIPTION
This adds a vnc server that can be installed from the CRT tools in batocera if the user wants to. Complete with dialog box via xterm. This contains the **required sh files**