### PR TITLE
Add VNC server to the setup script

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script.sh
@@ -1825,8 +1825,24 @@ fi
 	fi
 	chmod 755 /usr/bin/calibrate.py
 
+#######################################################################################
+# Add VNC server files to /lib & /usr/lib for v39
+#######################################################################################
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libcrypt.so.1 /lib/libcrypt.so.1 
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libcrypt.so.1 /usr/lib/libcrypt.so.1
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libvncclient.so.1 /usr/lib/libvncclient.so.1
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libvncserver.so.1 /usr/lib/libvncserver.so.1
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libsasl2.so.2 /usr/lib/libsasl2.so.2
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc /usr/bin/vnc
+cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/x11vnc /usr/bin/x11vnc
 
-
+chmod 0755 /lib/libcrypt.so.1
+chmod 0644 /usr/lib/libcrypt.so.1
+chmod 0644 /usr/lib/libvncclient.so.1
+chmod 0644 /usr/lib/libvncserver.so.1
+chmod 0644 /usr/lib/libsasl2.so.2
+chmod +x /usr/bin/vnc
+chmod +x /usr/bin/x11vnc
 
 #######################################################################################
 ## Save in compilation in batocera image


### PR DESCRIPTION
Adds vnc server files to batocera.
start server with the command 
`vnc` from terminal

Connect using TightVNC or UltraVNC

Courtesy of myzar and sirmagb