### PR TITLE
Add amd r9 freeze fix

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script.sh
@@ -312,6 +312,24 @@ case $selected_card in
 				reboot
 				exit
 			fi
+				# Define file paths for adding line to emulationstation configuration
+				source_file="/userdata/system/Batocera-CRT-Script/System_configs/R9/es_settings.cfg"
+				destination_file="/userdata/system/configs/emulationstation/es_settings.cfg"
+				line_to_add='<string name="GameTransitionStyle" value="instant" />'
+
+				# Check if destination file exists
+				if [ ! -f "$destination_file" ]; then
+				# Copy the source file to the destination
+				cp "$source_file" "$destination_file"
+				# Set correct file permissions
+				chmod 0644 "$destination_file"
+				fi
+
+				# Check if the line to add is already present in the destination file
+				if ! grep -qF "$line_to_add" "$destination_file"; then
+				# Add the line after <config> if it's not present
+				sed -i '/<\/config>/i '"$line_to_add"'' "$destination_file"
+			fi
 		else
 			R9_380="NO"
 			echo ""


### PR DESCRIPTION
This ensures that the code for modifying the emulationstation configuration is only executed when the graphics card is identified as an ATI R9 380/380x.