### PR TITLE
Update emulationstation-standalone-v38_ZFEbHVUE

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v38_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v38_ZFEbHVUE
@@ -75,20 +75,25 @@ do
 	    batocera-resolution minTomaxResolution-secure
     else
 ################### ZFEbHVUE ##########################################################################	    
-	    display_rotate="$(/usr/bin/batocera-settings-get-master display.rotate)"
-	    read WIDTH HEIGHT PARTHZ <<< $(echo ${bootresolution} | awk -F'[x.]' '{print $1, $2, $3 "." $4}')
-	    RES="${WIDTH}x${HEIGHT}"
-	     sed -i "s/--mode \".*\"/--mode \"$RES\"/"    /userdata/system/scripts/first_script.sh
+	   line=$(grep '^\(#\)\?es\.customsargs=' /userdata/system/batocera.conf)
+	   screenoffset_values=$(echo "$line" | awk '{match($0, /--screenoffset ([0-9]+) ([0-9]+)/, arr); print arr[1], arr[2]}')
+	   read screenoffset_x screenoffset_y <<< "$screenoffset_values"           
 
-	    if ([ "$display_rotate" == "1" ] || [ "$display_rotate" == "3" ]); then
-		es_arg="es.customsargs=--screensize "$HEIGHT" "$WIDTH" --screenoffset 00 00"
-	    else
-		es_arg="es.customsargs=--screensize "$WIDTH" "$HEIGHT" --screenoffset 00 00"
-	    fi
-	    sed -i "s/.*es.customsargs=.*/$es_arg/" 		/userdata/system/batocera.conf
+	   display_rotate="$(/usr/bin/batocera-settings-get-master display.rotate)"
+	   read WIDTH HEIGHT PARTHZ <<< $(echo ${bootresolution} | awk -F'[x.]' '{print $1, $2, $3 "." $4}')
+	   RES="${WIDTH}x${HEIGHT}"
+	   sed -i "s/--mode \".*\"/--mode \"$RES\"/"    /userdata/system/scripts/first_script.sh
 
-	    batocera-resolution defineMode "${bootresolution}"
-	    batocera-resolution setMode_CVT "${bootresolution}"
+	   if ([ "$display_rotate" == "1" ] || [ "$display_rotate" == "3" ]); then
+		es_arg="es.customsargs=--screensize "$HEIGHT" "$WIDTH" --screenoffset "$screenoffset_x" "$screenoffset_y"" 
+	   else
+		es_arg="es.customsargs=--screensize "$WIDTH" "$HEIGHT" --screenoffset "$screenoffset_y" "$screenoffset_x"" 
+	   fi
+
+	   sed -i "s/.*es.customsargs=.*/$es_arg/" 		/userdata/system/batocera.conf
+
+	   batocera-resolution defineMode "${bootresolution}"
+	   batocera-resolution setMode_CVT "${bootresolution}"
 
     fi
     ###################
@@ -100,7 +105,7 @@ do
     # TODO: Remove specific commands from emulationstation-standalone.
     if which xrandr # if xrandr available
     then
-        ### dpi override for nvidia gpus ###
+	### dpi override for nvidia gpus ###
         settings_output="$(batocera-settings-get global.dpi)"
         [ ! -z "${settings_output}" ] && batocera-resolution setDPI "${settings_output}"
         ###################


### PR DESCRIPTION
It takes now into account the last value read of --screenoffset into batocera.conf at the start.

