### PR TITLE
Update batocera-resolution-v38_Nvidia_driver_MYZAR_ZFEbHVUE

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v38_Nvidia_driver_MYZAR_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v38_Nvidia_driver_MYZAR_ZFEbHVUE
@@ -152,7 +152,7 @@ case "${ACTION}" in
 	DOTCLOCK_MIN_SWITCHRES=0
 
         sed -i "s/.*dotclock_min        .*/	dotclock_min              $DOTCLOCK_MIN_SWITCHRES/" /etc/switchres.ini
-	MODE_switchres=$(switchres  ${WIDTH} ${HEIGHT} ${PARTHZ} -f ${WIDTH}x${HEIGHT}@${PARTHZ}) #> /dev/null 2>/dev/null
+	MODE_switchres=$(switchres  ${WIDTH} ${HEIGHT} ${PARTHZ} -f ${WIDTH}x${HEIGHT}@${PARTHZ} -i switchres.ini -c) #> /dev/null 2>/dev/null
 	sed -i "s/.*dotclock_min        .*/	dotclock_min              $DOTCLOCK_MIN/" /etc/switchres.ini
 
 	MODELINE_CUSTOM="\"${RES_MODE}\" $(echo "$MODE_switchres" | sed -n 's/.*Modeline "[^"]*" \([0-9.]\+\) \([0-9 ]\+\) \(.*\)/\1 \2 \3/p')"


### PR DESCRIPTION
for rotation I made a mistake on batocera-resolution for defineMode) instead of calculate a modeline with switchres, i forgot to put -i switchres.ini -c. -c is only for the caculation and exit.

because the -c was not here, switchres generate a screen (good for normal but not for rotation ..)