### PR TITLE
Add backup and restore to main script

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script.sh
@@ -9,7 +9,7 @@ create_flag_file() {
     touch "$FLAG_FILE"
 }
 
-# Function to check if the flag file exists and prompt user for restore
+# Function to check if the flag file exists and prompt the user for restore
 check_flag_file() {
     # Path to the flag file
     FLAG_FILE="/userdata/system/Batocera-CRT-Script/backup.file"
@@ -24,7 +24,53 @@ check_flag_file() {
         case $? in
             0)
                 # User chose to run the restore script
-                /userdata/system/Batocera-CRT-Script/restore.sh
+                clear
+                echo "#######################################################################"
+                echo "##                                                                 ##"
+                echo "##                                                                 ##"
+                echo "##             This will restore files modified by the script      ##"
+                echo "##             Press Enter to Continue                             ##"
+                echo "##             Exit with Pause/Break key                           ##"
+                echo "##             The system will reboot                              ##"
+                echo "#######################################################################"
+                read
+                # Make boot writable
+                mount -o remount,rw /boot
+
+                # Batocera config file
+                install -D -m 0644 /userdata/system/Batocera-CRT-Script/backup/userdata/system/batocera.conf /userdata/system/batocera.conf
+
+                # Binary files
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/usr/bin/batocera-resolution.backup /usr/bin/batocera-resolution
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/usr/bin/emulationstation-standalone.backup /usr/bin/emulationstation-standalone
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/usr/bin/retroarch.backup /usr/bin/retroarch
+
+                # Python scripts
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/usr/lib/python3.11/site-packages/configgen/emulatorlauncher.py.backup /usr/lib/python3.11/site-packages/configgen/emulatorlauncher.py
+                install -D -m 0644 /userdata/system/Batocera-CRT-Script/backup/usr/lib/python3.11/site-packages/configgen/utils/videoMode.py.backup /usr/lib/python3.11/site-packages/configgen/utils/videoMode.py
+
+                # Boot Config
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/boot/batocera-boot.conf.backup /boot/batocera-boot.conf
+
+                # syslinux
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/boot/boot/syslinux.cfg.backup /boot/boot/syslinux.cfg
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/boot/boot/syslinux/syslinux.cfg.backup /boot/boot/syslinux/syslinux.cfg
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/boot/EFI/syslinux.cfg.backup /boot/EFI/syslinux.cfg
+                install -D -m 0755 /userdata/system/Batocera-CRT-Script/backup/boot/EFI/batocera/syslinux.cfg.backup /boot/EFI/batocera/syslinux.cfg
+
+                # Delete scripts but backup them first just in case.
+                install -D -m 0755 /userdata/system/scripts/1_GunCon2.sh /userdata/system/Batocera-CRT-Script/backup/userdata/system/scripts/1_GunCon2.sh.backup
+                install -D -m 0755 /userdata/system/scripts/first_script.sh /userdata/system/Batocera-CRT-Script/backup/userdata/system/scripts/first_script.sh.backup
+                cp -ra /userdata/system/scripts/1_GunCon2.sh /userdata/system/Batocera-CRT-Script/backup/userdata/system/scripts/1_GunCon2.sh.backup-$(date +"%m-%d-%y-%T")
+                cp -ra /userdata/system/scripts/first_script.sh /userdata/system/Batocera-CRT-Script/backup/userdata/system/scripts/first_script.sh.backup-$(date +"%m-%d-%y-%T")
+                rm -r /userdata/system/scripts/
+                install -D -m 0644 /userdata/system/videomodes.conf /userdata/system/Batocera-CRT-Script/backup/userdata/system/videomodes.conf.backup
+                cp -ra /userdata/system/videomodes.conf /userdata/system/Batocera-CRT-Script/backup/userdata/system/videomodes.conf.backup-$(date +"%m-%d-%y-%T")
+                rm /userdata/system/videomodes.conf
+
+                clear
+                batocera-save-overlay
+                reboot
                 ;;
             1)
                 # User chose not to run the restore script
@@ -33,28 +79,47 @@ check_flag_file() {
     fi
 }
 
-# Function to call the external script if the flag file doesn't exist
-call_external_script_once() {
+# Function to perform backup actions if the flag file doesn't exist
+perform_backup_once() {
     # Path to the flag file
     FLAG_FILE="/userdata/system/Batocera-CRT-Script/backup.file"
 
     # Check if the flag file exists
     if [ ! -f "$FLAG_FILE" ]; then
-        # Execute the external script
-        /userdata/system/Batocera-CRT-Script/backup.sh
-        
+        # Perform backup actions
+        # Batocera config file
+        install -D -m 0644 /userdata/system/batocera.conf /userdata/system/Batocera-CRT-Script/backup/userdata/system/batocera.conf
+
+        # Binary files
+        install -D -m 0755 /usr/bin/batocera-resolution /userdata/system/Batocera-CRT-Script/backup/usr/bin/batocera-resolution.backup
+        install -D -m 0755 /usr/bin/emulationstation-standalone /userdata/system/Batocera-CRT-Script/backup/usr/bin/emulationstation-standalone.backup
+        install -D -m 0755 /usr/bin/retroarch /userdata/system/Batocera-CRT-Script/backup/usr/bin/retroarch.backup
+
+        # Python scripts
+        install -D -m 0755 /usr/lib/python3.11/site-packages/configgen/emulatorlauncher.py /userdata/system/Batocera-CRT-Script/backup/usr/lib/python3.11/site-packages/configgen/emulatorlauncher.py.backup
+        install -D -m 0644 /usr/lib/python3.11/site-packages/configgen/utils/videoMode.py /userdata/system/Batocera-CRT-Script/backup/usr/lib/python3.11/site-packages/configgen/utils/videoMode.py.backup
+
+        # Boot Config
+        install -D -m 0755 /boot/batocera-boot.conf /userdata/system/Batocera-CRT-Script/backup/boot/batocera-boot.conf.backup
+
+        # syslinux
+        install -D -m 0755 /boot/boot/syslinux.cfg /userdata/system/Batocera-CRT-Script/backup/boot/boot/syslinux.cfg.backup
+        install -D -m 0755 /boot/boot/syslinux/syslinux.cfg /userdata/system/Batocera-CRT-Script/backup/boot/boot/syslinux/syslinux.cfg.backup
+        install -D -m 0755 /boot/EFI/syslinux.cfg /userdata/system/Batocera-CRT-Script/backup/boot/EFI/syslinux.cfg.backup
+        install -D -m 0755 /boot/EFI/batocera/syslinux.cfg /userdata/system/Batocera-CRT-Script/backup/boot/EFI/batocera/syslinux.cfg.backup
+
+        clear
+
         # Create the flag file
         create_flag_file
     fi
 }
 
+# Call the function to perform backup actions if the flag file doesn't exist
+perform_backup_once
+
 # Call the function to check if the flag file exists and prompt the user for restore
 check_flag_file
-
-# Call the function to call the external script only once
-call_external_script_once
-
-# Rest of your main script goes here...
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
This adds both the `backup.sh` and `restore.sh` scripts into the main setup script `Batocera-CRT-Script.sh`
Next pr will remove `backup.sh` and `restore.sh` scripts since they are already integrated correctly. 