### PR TITLE
VNC Server Scaling Script

### DIFF
--- a/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc-scaled
+++ b/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc-scaled
@@ -1,0 +1,7 @@
+#!/bin/bash
+export DISPLAY=:0
+/usr/bin/xrandr  -display :0.0 --output $(xrandr | grep -o '.* connected' | sed 's/ connected//') --transform none
+/usr/bin/xrandr -display :0.0 --output $(xrandr | grep -o '.* connected' | sed 's/ connected//') --scale-from 1920x1080
+x11vnc -forever -ncache 10
+/usr/bin/xrandr  -display :0.0 --output $(xrandr | grep -o '.* connected' | sed 's/ connected//') --transform none
+


### PR DESCRIPTION
There are built in commands for scaling mention in the man pages for **x11vnc** but they work really lousy and make everything really slow. Since the only thing important for us is to scale the xfce window then we can use xrandr transform instead.  Emulation Station will still be in your boot resolution i.e. 640x480 

But as default it's setup to use 1080p and that is more then enough.