### PR TITLE
Update emulationstation-standalone-v38_ZFEbHVUE

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v38_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v38_ZFEbHVUE
@@ -70,6 +70,7 @@ do
 
     ### resolution ###
     bootresolution="$(batocera-settings-get-master -f "$BOOTCONF" es.resolution)"
+    bootresolution=$(echo $bootresolution | sed 's/.\{3\}$//')
     if test -z "${bootresolution}"
     then
 	    batocera-resolution minTomaxResolution-secure


### PR DESCRIPTION
Only change the way we get bootresolution   where we cut 3 digit of the number of the lines into videomodes. 
bootresolution=$(echo $bootresolution | sed 's/.\{3\}$//')