### PR TITLE
Update emulationstation-standalone-v38_ZFEbHVUE

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v38_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v38_ZFEbHVUE
@@ -70,7 +70,13 @@ do
 
     ### resolution ###
     bootresolution="$(batocera-settings-get-master -f "$BOOTCONF" es.resolution)"
-    bootresolution=$(echo $bootresolution | sed 's/.\{3\}$//')
+    
+    after_last_dot=$(echo "$bootresolution" | sed 's/.*\.//')
+    digit_count=$(echo "$after_last_dot" | grep -o '[0-9]' | wc -l)
+    if [ "$digit_count" -ge 5 ]; then
+    	bootresolution=$(echo "$bootresolution" | sed 's/.\{3\}$//')
+    fi
+
     if test -z "${bootresolution}"
     then
 	    batocera-resolution minTomaxResolution-secure


### PR DESCRIPTION
Add more tests about the digit of frequency   for ES  (not for games)

If the digit is   60.00150   the freqency becomes 60.00 for the calcul of switchres.
If the digit is   60.00    the freqency doesn't change for the calcul of switchres.

I did it because in videomodes (frontend developer options) : there are also the edid / Es resolution for example : 768x576i 49.97  and 768x576 49.97  so we don't need to put away the 3 digits. but we can choose alsofoe ES  the 640x480 using for games and here we need to put away the 3 digits 

This Es-standalone is able to do it ;)