### PR TITLE
Add Grid Tool and fix pad2keys part1

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v40.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v40.sh
@@ -1826,14 +1826,15 @@ cp -a /userdata/system/Batocera-CRT-Script/Geometry_modeline/crt/ /userdata/roms
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt.cfg /userdata/system/configs/emulationstation/es_systems_crt.cfg
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.png /usr/share/emulationstation/themes/es-theme-carbon/art/consoles/CRT.png
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.svg /usr/share/emulationstation/themes/es-theme-carbon/art/logos/CRT.svg
-cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/geometry.sh.keys /usr/share/evmapy/
-cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_tool.sh.keys /usr/share/evmapy/
 chmod 755 /userdata/roms/crt/es_adjust_tool.sh
 chmod 755 /userdata/roms/crt/geometry.sh
 chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_tool.sh
 chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/geometry.sh
-chmod 755 /usr/share/evmapy/es_tool.sh.keys
-chmod 755 /usr/share/evmapy/geometry.sh.keys
+chmod 0644 /userdata/roms/crt/es_tool.sh.keys
+chmod 0644 /userdata/roms/crt/geometry.sh.keys
+chmod 755 /userdata/roms/crt/grid_tool.sh
+chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/grid_tool.sh
+chmod 0644 /userdata/roms/crt/grid_tool.sh.keys
 
 #######################################################################################
 # Create geometryForVideomodes.sh  for adjusting resoltuion in videomodes.conf for your CRT

--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
@@ -1874,14 +1874,15 @@ cp -a /userdata/system/Batocera-CRT-Script/Geometry_modeline/crt/ /userdata/roms
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt.cfg /userdata/system/configs/emulationstation/es_systems_crt.cfg
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.png /usr/share/emulationstation/themes/es-theme-carbon/art/consoles/CRT.png
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.svg /usr/share/emulationstation/themes/es-theme-carbon/art/logos/CRT.svg
-cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/geometry.sh.keys /usr/share/evmapy/
-cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_tool.sh.keys /usr/share/evmapy/
 chmod 755 /userdata/roms/crt/es_adjust_tool.sh
 chmod 755 /userdata/roms/crt/geometry.sh
 chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_tool.sh
 chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/geometry.sh
-chmod 755 /usr/share/evmapy/es_tool.sh.keys
-chmod 755 /usr/share/evmapy/geometry.sh.keys
+chmod 0644 /userdata/roms/crt/es_tool.sh.keys
+chmod 0644 /userdata/roms/crt/geometry.sh.keys
+chmod 755 /userdata/roms/crt/grid_tool.sh
+chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/grid_tool.sh
+chmod 0644 /userdata/roms/crt/grid_tool.sh.keys
 
 #######################################################################################
 # Create geometryForVideomodes.sh  for adjusting resoltuion in videomodes.conf for your CRT


### PR DESCRIPTION
Added
/userdata/roms/crt/grid_tool.sh
/userdata/roms/crt/grid_tool.sh.keys
/userdata/system/Batocera-CRT-Script/Geometry_modeline/grid_tool.sh

Fixed pad2key files not working for 
es_tool.sh
geometry.sh