### PR TITLE
Update multimedia_keys.conf

### DIFF
--- a/userdata/system/Batocera-CRT-Script/extra/media_keys/multimedia_keys.conf
+++ b/userdata/system/Batocera-CRT-Script/extra/media_keys/multimedia_keys.conf
@@ -5,8 +5,9 @@ KEY_VOLUMEDOWN 2                batocera-audio setSystemVolume -5
 KEY_MUTE        1               batocera-audio setSystemVolume mute-toggle
 KEY_POWER       1               batocera-shutdown 1
 KEY_POWER       0               batocera-shutdown 0
-KEY_F2+KEY_LEFTALT          1               bash /usr/bin/xrestart
-KEY_F1+KEY_LEFTALT          1               bash /usr/bin/esrestart
+KEY_F3+KEY_RIGHTALT          1               bash /usr/bin/emukill
+KEY_F2+KEY_RIGHTALT          1               bash /usr/bin/xrestart
+KEY_F1+KEY_RIGHTALT          1               bash /usr/bin/esrestart
 KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop
 KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 chvt 1
 KEY_LEFTMETA    1               batocera-brightness cycle


### PR DESCRIPTION
Changed from 

KEY_LEFTALT+Function 
to 
KEY_RIGHTALT+Function (AltGr (also Alt Graph) + Funtion)

Added emukill (batocera-es-swissknife --emukill) to F3 key

This is so the extra function keys are not pressed by accident since Alt+F4 normally exits an Emulator or Application.