### PR TITLE
Update Batocera-CRT-Script-v41.sh

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
@@ -105,6 +105,7 @@ check_flag_file() {
                 # User chose to quit
                 clear
                 echo "Exiting back to terminal."
+                exit 0
                 ;;
         esac
     fi


### PR DESCRIPTION
Fixes exit function for Script in the restore menu.