### PR TITLE
Update Batocera-CRT-Script-v40.sh

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v40.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v40.sh
@@ -667,7 +667,7 @@ if ([ "$TYPE_OF_CARD" == "NVIDIA" ] && [ "$Drivers_Nvidia_CHOICE" == "Nvidia_Dri
             	"vesa_1024 640x480@60 768x576@50 800x600@60 1024x576@50 1024x768@50")
  
  
-    if [ "$TYPE_CARD" == "AMD/ATI" ] && [ "$AMD_IS_APU" == 1 ]; then
+    if [ "$TYPE_OF_CARD" == "AMD/ATI" ] && [ "$AMD_IS_APU" == 1 ]; then
         IFE=1
     else
         IFE=0
@@ -1671,7 +1671,8 @@ case $Version_of_batocera in
 		chmod 755 /usr/bin/batocera-resolution 
 		chmod 755 /usr/bin/emulationstation-standalone
 		sed -e "s/\[monitor-name\]/$monitor_name_MAME/g" -e "s/\[super_width\]/$super_width/g" -e "s/\[dotclock_min_value\]/$dotclock_min/g"  /userdata/system/Batocera-CRT-Script/etc_configs/switchres.ini-generic-v36 > /etc/switchres.ini
-		chmod 755 /etc/switchres.ini
+		sed -i "s/.*interlace_force_even   .*/        interlace_force_even      $IFE/" /etc/switchres.ini
+  		chmod 755 /etc/switchres.ini
 
 		cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/get_monitorRange  /usr/bin/get_monitorRange
 		chmod 755 /usr/bin/get_monitorRange
@@ -1711,7 +1712,8 @@ case $Version_of_batocera in
 		chmod 755 /usr/bin/batocera-resolution 
 		chmod 755 /usr/bin/emulationstation-standalone
 		sed -e "s/\[monitor-name\]/$monitor_name_MAME/g" -e "s/\[super_width\]/$super_width/g" -e "s/\[dotclock_min_value\]/$dotclock_min/g"  /userdata/system/Batocera-CRT-Script/etc_configs/switchres.ini-generic-v36 > /etc/switchres.ini
-		chmod 755 /etc/switchres.ini
+		sed -i "s/.*interlace_force_even   .*/        interlace_force_even      $IFE/" /etc/switchres.ini
+  		chmod 755 /etc/switchres.ini
 
 		cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/get_monitorRange  /usr/bin/get_monitorRange
 		chmod 755 /usr/bin/get_monitorRange


### PR DESCRIPTION
there is a problems Caps/Min of the grep test
 
There is a mistake if [ "$TYPE_CARD" == "AMD/ATI" ] && [ "$AMD_IS_APU" == 1 ]; then


if [ "$TYPE_OF_CARD" == "AMD/ATI" ] && [ "$AMD_IS_APU" == 1 ]; then