### PR TITLE
Update Batocera-CRT-Script-v41.sh

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
@@ -2183,7 +2183,7 @@ fi
 #######################################################################################
 # Add VNC server files to /lib & /usr/lib for v41
 #######################################################################################
-mv /lib/libcrypt.so.1 /lib/libcrypt.so.1.bak
+#mv /lib/libcrypt.so.1 /lib/libcrypt.so.1.bak
 cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libcrypt.so.1 /lib/libcrypt.so.1 
 cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libcrypt.so.1 /usr/lib/libcrypt.so.1
 cp /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/libvncclient.so.1 /usr/lib/libvncclient.so.1


### PR DESCRIPTION
Fixes error 
mv: cannot stat '/lib/libcrypt.so.1': No such file or directory For v41