### PR TITLE
v41 es_settings for R9 380(X) New File

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/R9/v41/es_settings.cfg
+++ b/userdata/system/Batocera-CRT-Script/System_configs/R9/v41/es_settings.cfg
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config>
+	<string name="LastSystem" value="c64" />
+	<string name="ThemeSet" value="es-theme-carbon" />
+	<string name="GameTransitionStyle" value="instant" />
+</config>


### PR DESCRIPTION
Fixes the issue where the es_settings.cfg is not edited correctly for v41. Apparently I missed there where changes in that file between v40 & v41

New File