### PR TITLE
R9 380, Small fix for duplicate lines.

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v41.sh
@@ -508,25 +508,27 @@ case $selected_card in
 				read
 				reboot
 				exit
-                              fi
-				# Define file paths for adding line to emulationstation configuration
+
+				fi
+				# Define file paths for adding line to EmulationStation configuration
 				source_file="/userdata/system/Batocera-CRT-Script/System_configs/R9/v41/es_settings.cfg"
 				destination_file="/userdata/system/configs/emulationstation/es_settings.cfg"
-				line_to_add='        <string name="GameTransitionStyle" value="instant" />'
 
 				# Check if destination file exists
 				if [ ! -f "$destination_file" ]; then
-				# Copy the source file to the destination
-				cp "$source_file" "$destination_file"
-				# Set correct file permissions
-				chmod 0644 "$destination_file"
+				    # Copy the source file to the destination
+				    cp "$source_file" "$destination_file"
+				    # Set correct file permissions
+				    chmod 0644 "$destination_file"
+				else
+				    # Ensure "GameTransitionStyle" is at the top, otherwise replace the file
+				    if ! grep -q '<string name="GameTransitionStyle" value="instant" />' "$destination_file"; then
+				        cp "$source_file" "$destination_file"
+				        chmod 0644 "$destination_file"
+				    fi
 				fi
 
-				# Check if the line to add is already present in the destination file
-				if ! grep -qF "$line_to_add" "$destination_file"; then
-				# Add the line after <config> if it's not present
-				sed -i '/<\/config>/i\'"$line_to_add"'' "$destination_file"
-				fi
+
 		else
 			R9_380="NO"
 			echo ""

--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
@@ -516,25 +516,26 @@ case $selected_card in
 				read
 				reboot
 				exit
-			fi
-				# Define file paths for adding line to emulationstation configuration
-				source_file="/userdata/system/Batocera-CRT-Script/System_configs/R9/es_settings.cfg"
+			
+				fi
+				# Define file paths for adding line to EmulationStation configuration
+				source_file="/userdata/system/Batocera-CRT-Script/System_configs/R9/v41/es_settings.cfg"
 				destination_file="/userdata/system/configs/emulationstation/es_settings.cfg"
-				line_to_add='<string name="GameTransitionStyle" value="instant" />'
 
 				# Check if destination file exists
 				if [ ! -f "$destination_file" ]; then
-				# Copy the source file to the destination
-				cp "$source_file" "$destination_file"
-				# Set correct file permissions
-				chmod 0644 "$destination_file"
+				    # Copy the source file to the destination
+				    cp "$source_file" "$destination_file"
+				    # Set correct file permissions
+				    chmod 0644 "$destination_file"
+				else
+				    # Ensure "GameTransitionStyle" is at the top, otherwise replace the file
+				    if ! grep -q '<string name="GameTransitionStyle" value="instant" />' "$destination_file"; then
+				        cp "$source_file" "$destination_file"
+				        chmod 0644 "$destination_file"
+				    fi
 				fi
-
-				# Check if the line to add is already present in the destination file
-				if ! grep -qF "$line_to_add" "$destination_file"; then
-				# Add the line after <config> if it's not present
-				sed -i '/<\/config>/i '"$line_to_add"'' "$destination_file"
-				fi
+		
 		else
 			R9_380="NO"
 			echo ""


### PR DESCRIPTION
Small fix for duplicate lines being added in 
`/userdata/system/configs/emulationstation/es_settings.cfg` for R9 380 cards
Also added fix for v42

Example of issue where 
```
<string name="GameTransitionStyle" value="instant" />
```
Was added twice

```
<?xml version="1.0"?>
<config>
	<string name="GameTransitionStyle" value="instant" />
	<string name="LastSystem" value="c64" />
	<string name="ShowFlags" value="auto" />
	<string name="ThemeSet" value="es-theme-carbon" />
        <string name="GameTransitionStyle" value="instant" />
</config>
```