### PR TITLE
Fix for CRT System now working in v42 (New CFG)

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt_v42.cfg
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt_v42.cfg
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<systemList>
+  <system>
+        <fullname>Ports</fullname>
+        <name>ports</name>
+        <manufacturer>Ports</manufacturer>
+        <release>None</release>
+        <hardware>port</hardware>
+        <path>/userdata/roms/crt</path>
+        <extension>.sh</extension>
+        <command>emulatorlauncher %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM% -gameinfoxml %GAMEINFOXML% -systemname %SYSTEMNAME%</command>
+        <platform>pc</platform>
+        <theme>CRT</theme>
+        <group>CRT</group>
+        <emulators>
+            <emulator name="sh">
+                <cores>
+                    <core default="true">sh</core>
+                </cores>
+            </emulator>
+        </emulators>
+  </system>
+
+</systemList>


### PR DESCRIPTION
This fixes the issue for unknown emulator system in ES for V42  Where CRT System shows up but is unable the be executed