### PR TITLE
force x11vnc to always use port 5900

### DIFF
--- a/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc
+++ b/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 export DISPLAY=:0
-x11vnc -forever -noxdamage
 
+# Kill any existing x11vnc instances using port 5900 (optional but safer)
+fuser -k 5900/tcp
+
+# Start x11vnc on port 5900
+x11vnc -forever -noxdamage -rfbport 5900 -shared

--- a/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc-scaled
+++ b/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/vnc-scaled
@@ -2,6 +2,11 @@
 export DISPLAY=:0
 /usr/bin/xrandr  -display :0.0 --output $(xrandr | grep -o '.* connected' | sed 's/ connected//') --transform none
 /usr/bin/xrandr -display :0.0 --output $(xrandr | grep -o '.* connected' | sed 's/ connected//') --scale-from 1920x1080
-x11vnc -forever -noxdamage
+
+# Kill any existing x11vnc instances using port 5900 (optional but safer)
+fuser -k 5900/tcp
+
+# Start x11vnc on port 5900
+x11vnc -forever -noxdamage -rfbport 5900 -shared
 /usr/bin/xrandr  -display :0.0 --output $(xrandr | grep -o '.* connected' | sed 's/ connected//') --transform none
 


### PR DESCRIPTION
There was an issue with VNC where it would change the default port from 5900 to 5901, 5902 after  
xrestart
batocera-es-swissknife --restart
Suspend/Resume

The behavior happens because x11vnc automatically increments the port number (5901, 5902, etc.) if port 5900 is already in use (often due to a stale or zombie VNC instance still holding it after suspend/resume).

* fuser -k 5900/tcp: Kills the process currently using TCP port 5900 (if any). This ensures a clean start. 
* -rfbport 5900: Explicitly sets the port. Without this, x11vnc starts at 5900 but will auto-increment if in use.
* -shared: Support for multiple viewers to connect without kicking the previous one.