### PR TITLE
Kodi in Ports sh file

### DIFF
--- a/userdata/system/Batocera-CRT-Script/extra/Kodi/Kodi.sh
+++ b/userdata/system/Batocera-CRT-Script/extra/Kodi/Kodi.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/kodi


### PR DESCRIPTION
Kodi can now be started from Ports folder and you can use VideoMode to select the resolution you want it to start up in.

Since we have no way of choosing what type of resolution we want Kodi to Start in from EmulationStation this is a workaround for that.