### PR TITLE
Kodi in Ports v42

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
@@ -2257,6 +2257,12 @@ chmod 755 /usr/bin/xrestart
 chmod 755 /usr/bin/emukill
 
 #######################################################################################
+# Add Kodi to ports folder
+#######################################################################################
+cp /userdata/system/Batocera-CRT-Script/extra/Kodi/Kodi.sh /userdata/roms/ports
+chmod 755 /userdata/roms/ports/Kodi.sh
+
+#######################################################################################
 ## Save in compilation in batocera image
 #######################################################################################
 batocera-save-overlay


### PR DESCRIPTION

Kodi can now be started from Ports folder and you can use VideoMode to select the resolution you want it to start up in.

Since we have no way of choosing what type of resolution we want Kodi to Start in from EmulationStation this is a workaround for that.