### PR TITLE
Custom CRT Range Preservation v41 & v42

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_MYZAR_ZFEbHVUE-MultiScreen
@@ -192,15 +192,44 @@ case "${ACTION}" in
         unset IFS
 
 	Monitor_name=$(awk '/Monitor Type:/{print $3}' "$log_file_monitor")
-	crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
 	Monitor_custom=$(grep -v "^#" "$Switchres_file" | grep "monitor" | head -1 | awk '{print $2}')
 	Monitor_default="custom"
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_default/" "$Switchres_file"
- 	crt_range_custom=$(grep -oP '^\s*crt_range0\s+\K.*' "$Switchres_file")
- 	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_setmode/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	declare -A crt_ranges_backup
+	for i in {0..9}; do
+		range=$(grep -oP "^\s*crt_range${i}\s+\K.*" "$Switchres_file")
+		if [[ -n "$range" ]]; then
+			crt_ranges_backup[$i]="$range"
+		fi
+	done
+
+	# Temporarily set monitor to "custom"
+	sed -i "s/.*monitor        .*/    monitor              $Monitor_default/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	for i in "${!crt_ranges_backup[@]}"; do
+		if grep -q "^[[:space:]]*crt_range${i}[[:space:]]\+" "$Switchres_file"; then
+		   # Replace if line exists
+           sed -i "s|^\s*crt_range${i}\s\+.*|	crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+      else
+           # Append if missing
+           echo -e "\tcrt_range${i}              ${crt_ranges_backup[$i]}" >> "$Switchres_file"
+      fi
+  done
+
+	# Only override crt_range0 if monitor is not custom
+	if [[ "$Monitor_name" != "custom" ]]; then
+		crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
+		sed -i "s/.*crt_range0        .*/    crt_range0              $crt_range_setmode/" "$Switchres_file"
+	else
+		echo "[INFO] monitor=custom — preserving user-defined crt_range0–crt_range9 from switchres.ini"
+	fi
+
 	DOTCLOCK_MAX=25.0
 	DOTCLOCK_MIN=$(grep -v "^#" /etc/switchres.ini | grep "dotclock_min" | head -1 | awk '{print $2}')
 
+	
 	#version bash
 	if (( $(echo "$DOTCLOCK_MIN >= $DOTCLOCK_MAX" | bc -l) )); then
     		sed -i "s/.*dotclock_min        .*/	dotclock_min              0/" "$Switchres_file"
@@ -211,12 +240,16 @@ case "${ACTION}" in
     	#	sed -i "s/.*dotclock_min        .*/	dotclock_min              0/" "$Switchres_file"
 	#fi
 
-	game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+    game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
 
+    # Restore monitor and dotclock_min
+    sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"
+    sed -i "s/.*dotclock_min        .*/    dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
 
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_custom/" "$Switchres_file"
-	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_custom/" "$Switchres_file"
-	sed -i "s/.*dotclock_min        .*/	dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
+    # Restore all crt_range0–9
+    for i in "${!crt_ranges_backup[@]}"; do
+        sed -i "s|^[[:space:]]*crt_range${i}[[:space:]]\+.*|    crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+    done	
 
         
 	cp "$Switchres_file" /userdata/system/logs/Switchres_game.ini

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
@@ -192,12 +192,40 @@ case "${ACTION}" in
         unset IFS
 
 	Monitor_name=$(awk '/Monitor Type:/{print $3}' "$log_file_monitor")
-	crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
 	Monitor_custom=$(grep -v "^#" "$Switchres_file" | grep "monitor" | head -1 | awk '{print $2}')
 	Monitor_default="custom"
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_default/" "$Switchres_file"
- 	crt_range_custom=$(grep -oP '^\s*crt_range0\s+\K.*' "$Switchres_file")
- 	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_setmode/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	declare -A crt_ranges_backup
+	for i in {0..9}; do
+		range=$(grep -oP "^\s*crt_range${i}\s+\K.*" "$Switchres_file")
+		if [[ -n "$range" ]]; then
+			crt_ranges_backup[$i]="$range"
+		fi
+	done
+
+	# Temporarily set monitor to "custom"
+	sed -i "s/.*monitor        .*/    monitor              $Monitor_default/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	for i in "${!crt_ranges_backup[@]}"; do
+		if grep -q "^[[:space:]]*crt_range${i}[[:space:]]\+" "$Switchres_file"; then
+		   # Replace if line exists
+           sed -i "s|^\s*crt_range${i}\s\+.*|	crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+      else
+           # Append if missing
+           echo -e "\tcrt_range${i}              ${crt_ranges_backup[$i]}" >> "$Switchres_file"
+      fi
+  done
+
+	# Only override crt_range0 if monitor is not custom
+	if [[ "$Monitor_name" != "custom" ]]; then
+		crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
+		sed -i "s/.*crt_range0        .*/    crt_range0              $crt_range_setmode/" "$Switchres_file"
+	else
+		echo "[INFO] monitor=custom — preserving user-defined crt_range0–crt_range9 from switchres.ini"
+	fi
+
 	DOTCLOCK_MAX=25.0
 	DOTCLOCK_MIN=$(grep -v "^#" /etc/switchres.ini | grep "dotclock_min" | head -1 | awk '{print $2}')
 
@@ -211,13 +239,16 @@ case "${ACTION}" in
     	#	sed -i "s/.*dotclock_min        .*/	dotclock_min              0/" "$Switchres_file"
 	#fi
 
-	game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+   game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
 
+    # Restore monitor and dotclock_min
+    sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"
+    sed -i "s/.*dotclock_min        .*/    dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
 
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_custom/" "$Switchres_file"
-	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_custom/" "$Switchres_file"
-	sed -i "s/.*dotclock_min        .*/	dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
-
+    # Restore all crt_range0–9
+    for i in "${!crt_ranges_backup[@]}"; do
+        sed -i "s|^[[:space:]]*crt_range${i}[[:space:]]\+.*|    crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+    done	
         
 	cp "$Switchres_file" /userdata/system/logs/Switchres_game.ini
 	if [ -f "$info_game" ]; then 

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_MYZAR_ZFEbHVUE-MultiScreen
@@ -229,14 +229,43 @@ case "${ACTION}" in
         unset IFS
 
 	Monitor_name=$(awk '/Monitor Type:/{print $3}' "$log_file_monitor")
-	crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
 	Monitor_custom=$(grep -v "^#" "$Switchres_file" | grep "monitor" | head -1 | awk '{print $2}')
 	Monitor_default="custom"
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_default/" "$Switchres_file"
- 	crt_range_custom=$(grep -oP '^\s*crt_range0\s+\K.*' "$Switchres_file")
- 	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_setmode/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	declare -A crt_ranges_backup
+	for i in {0..9}; do
+		range=$(grep -oP "^\s*crt_range${i}\s+\K.*" "$Switchres_file")
+		if [[ -n "$range" ]]; then
+			crt_ranges_backup[$i]="$range"
+		fi
+	done
+
+	# Temporarily set monitor to "custom"
+	sed -i "s/.*monitor        .*/    monitor              $Monitor_default/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	for i in "${!crt_ranges_backup[@]}"; do
+		if grep -q "^[[:space:]]*crt_range${i}[[:space:]]\+" "$Switchres_file"; then
+		   # Replace if line exists
+           sed -i "s|^\s*crt_range${i}\s\+.*|	crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+      else
+           # Append if missing
+           echo -e "\tcrt_range${i}              ${crt_ranges_backup[$i]}" >> "$Switchres_file"
+      fi
+  done
+
+	# Only override crt_range0 if monitor is not custom
+	if [[ "$Monitor_name" != "custom" ]]; then
+		crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
+		sed -i "s/.*crt_range0        .*/    crt_range0              $crt_range_setmode/" "$Switchres_file"
+	else
+		echo "[INFO] monitor=custom — preserving user-defined crt_range0–crt_range9 from switchres.ini"
+	fi
+
 	DOTCLOCK_MAX=25.0
 	DOTCLOCK_MIN=$(grep -v "^#" /etc/switchres.ini | grep "dotclock_min" | head -1 | awk '{print $2}')
+	
 
 	#version bash
 	if (( $(echo "$DOTCLOCK_MIN >= $DOTCLOCK_MAX" | bc -l) )); then
@@ -248,13 +277,16 @@ case "${ACTION}" in
     	#	sed -i "s/.*dotclock_min        .*/	dotclock_min              0/" "$Switchres_file"
 	#fi
 
-	game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+    game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
 
+    # Restore monitor and dotclock_min
+    sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"
+    sed -i "s/.*dotclock_min        .*/    dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
 
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_custom/" "$Switchres_file"
-	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_custom/" "$Switchres_file"
-	sed -i "s/.*dotclock_min        .*/	dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
-
+    # Restore all crt_range0–9
+    for i in "${!crt_ranges_backup[@]}"; do
+        sed -i "s|^[[:space:]]*crt_range${i}[[:space:]]\+.*|    crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+    done	
         
 	cp "$Switchres_file" /userdata/system/logs/Switchres_game.ini
 	if [ -f "$info_game" ]; then 

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
@@ -229,12 +229,40 @@ case "${ACTION}" in
         unset IFS
 
 	Monitor_name=$(awk '/Monitor Type:/{print $3}' "$log_file_monitor")
-	crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
 	Monitor_custom=$(grep -v "^#" "$Switchres_file" | grep "monitor" | head -1 | awk '{print $2}')
 	Monitor_default="custom"
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_default/" "$Switchres_file"
- 	crt_range_custom=$(grep -oP '^\s*crt_range0\s+\K.*' "$Switchres_file")
- 	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_setmode/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	declare -A crt_ranges_backup
+	for i in {0..9}; do
+		range=$(grep -oP "^\s*crt_range${i}\s+\K.*" "$Switchres_file")
+		if [[ -n "$range" ]]; then
+			crt_ranges_backup[$i]="$range"
+		fi
+	done
+
+	# Temporarily set monitor to "custom"
+	sed -i "s/.*monitor        .*/    monitor              $Monitor_default/" "$Switchres_file"
+
+	# Backup all crt_rangeN entries (0–9)
+	for i in "${!crt_ranges_backup[@]}"; do
+		if grep -q "^[[:space:]]*crt_range${i}[[:space:]]\+" "$Switchres_file"; then
+		   # Replace if line exists
+           sed -i "s|^\s*crt_range${i}\s\+.*|	crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+      else
+           # Append if missing
+           echo -e "\tcrt_range${i}              ${crt_ranges_backup[$i]}" >> "$Switchres_file"
+      fi
+  done
+
+	# Only override crt_range0 if monitor is not custom
+	if [[ "$Monitor_name" != "custom" ]]; then
+		crt_range_setmode=$(get_monitorRange "$Monitor_name" "$Hfreq" "$Vfreq")
+		sed -i "s/.*crt_range0        .*/    crt_range0              $crt_range_setmode/" "$Switchres_file"
+	else
+		echo "[INFO] monitor=custom — preserving user-defined crt_range0–crt_range9 from switchres.ini"
+	fi
+
 	DOTCLOCK_MAX=25.0
 	DOTCLOCK_MIN=$(grep -v "^#" /etc/switchres.ini | grep "dotclock_min" | head -1 | awk '{print $2}')
 
@@ -248,13 +276,16 @@ case "${ACTION}" in
     	#	sed -i "s/.*dotclock_min        .*/	dotclock_min              0/" "$Switchres_file"
 	#fi
 
-	game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+    game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
 
+    # Restore monitor and dotclock_min
+    sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"
+    sed -i "s/.*dotclock_min        .*/    dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
 
-	sed -i "s/.*monitor        .*/	monitor              $Monitor_custom/" "$Switchres_file"
-	sed -i "s/.*crt_range0        .*/	crt_range0              $crt_range_custom/" "$Switchres_file"
-	sed -i "s/.*dotclock_min        .*/	dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"
-
+    # Restore all crt_range0–9
+    for i in "${!crt_ranges_backup[@]}"; do
+        sed -i "s|^[[:space:]]*crt_range${i}[[:space:]]\+.*|    crt_range${i}              ${crt_ranges_backup[$i]}|" "$Switchres_file"
+    done	
         
 	cp "$Switchres_file" /userdata/system/logs/Switchres_game.ini
 	if [ -f "$info_game" ]; then 


### PR DESCRIPTION
### 🛠️ Summary of Fixes: Custom CRT Range Preservation in `switchres.ini`

This PR ensures correct handling of custom `crt_range0–9` values in `switchres.ini` based on the selected monitor profile.

#### ✅ Key Fixes:
- **Preserve user-defined `crt_range0–9`** when `monitor=custom`.
- **Avoid overwriting `crt_range0`** with automatic profile values when using a custom monitor.
- **Back up and fully restore all `crt_range0–9` entries** after calling `switchres`, only if `monitor=custom`.
- **Do not delete or alter `crt_range1–9`** when using predefined profiles like `arcade_15` — they remain in the config, but are ignored as expected by `switchres`.
- **Restored `monitor` and `dotclock_min`** values post-call, maintaining full integrity of the original config.
- **Clean behavior when switching between custom and stock monitor profiles**, allowing seamless testing and fallback.

#### 💡 Additional Notes:
- Lines like `crt_range0              auto` will be safely preserved or restored unless explicitly overwritten.
- Duplicate or malformed `crt_range0` entries are now avoided.
- Helpful logging lines were added for clarity when using `monitor=custom` or predefined profiles.