### PR TITLE
Improve batocera-resolution modeline cleanup & tracking v41, v42

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_MYZAR_ZFEbHVUE-MultiScreen
@@ -4,6 +4,30 @@ log="/userdata/system/logs/display.log"
 mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
 
+# --- Clean up previous switchres modeline - start ---
+STATE_FILE="/tmp/switchres-last-resolution-state"
+
+if [ -f "$STATE_FILE" ]; then
+    read -r LAST_OUTPUT LAST_MODE < "$STATE_FILE"
+    CURRENT_MODE=$(xrandr --verbose | awk -v out="$LAST_OUTPUT" '
+        $0 ~ "^"out {found=1}
+        found && / connected/ {found=0}
+        found && /[0-9]+x[0-9]+/ && /\*/ {print $1; exit}
+    ')
+
+    if [ "$CURRENT_MODE" = "$LAST_MODE" ]; then
+        echo "[batocera-resolution] Skipping deletion of $LAST_MODE because it is currently active on $LAST_OUTPUT" >> $log
+    elif xrandr | grep -q "$LAST_MODE"; then
+        echo "[batocera-resolution] Deleting modeline $LAST_MODE from output $LAST_OUTPUT" >> $log
+        xrandr --delmode "$LAST_OUTPUT" "$LAST_MODE"
+    else
+        echo "[batocera-resolution] Previous modeline $LAST_MODE not found, skipping deletion" >> $log
+    fi
+
+    rm -f "$STATE_FILE"
+fi
+# --- Clean up previous switchres modeline - end ---
+
 PSCREEN=
 if test "${1}" = "--screen"
 then
@@ -241,6 +265,15 @@ case "${ACTION}" in
 	#fi
 
     game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+
+	# --- Log newly generated modeline for future cleanup - start ---
+	NEW_MODE=$(xrandr | grep 'SR-1_' | awk '{print $1}' | tail -n1)
+
+	if [ -n "$NEW_MODE" ] && [ -n "$OUTPUT" ]; then
+		echo "$OUTPUT $NEW_MODE" > /tmp/switchres-last-resolution-state
+		echo "[batocera-resolution] Stored modeline state: $NEW_MODE on $OUTPUT" >> $log
+	fi
+	# --- Log newly generated modeline for future cleanup - end ---
 
     # Restore monitor and dotclock_min
     sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v41_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
@@ -4,6 +4,30 @@ log="/userdata/system/logs/display.log"
 mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
 
+# --- Clean up previous switchres modeline - start ---
+STATE_FILE="/tmp/switchres-last-resolution-state"
+
+if [ -f "$STATE_FILE" ]; then
+    read -r LAST_OUTPUT LAST_MODE < "$STATE_FILE"
+    CURRENT_MODE=$(xrandr --verbose | awk -v out="$LAST_OUTPUT" '
+        $0 ~ "^"out {found=1}
+        found && / connected/ {found=0}
+        found && /[0-9]+x[0-9]+/ && /\*/ {print $1; exit}
+    ')
+
+    if [ "$CURRENT_MODE" = "$LAST_MODE" ]; then
+        echo "[batocera-resolution] Skipping deletion of $LAST_MODE because it is currently active on $LAST_OUTPUT" >> $log
+    elif xrandr | grep -q "$LAST_MODE"; then
+        echo "[batocera-resolution] Deleting modeline $LAST_MODE from output $LAST_OUTPUT" >> $log
+        xrandr --delmode "$LAST_OUTPUT" "$LAST_MODE"
+    else
+        echo "[batocera-resolution] Previous modeline $LAST_MODE not found, skipping deletion" >> $log
+    fi
+
+    rm -f "$STATE_FILE"
+fi
+# --- Clean up previous switchres modeline - end ---
+
 PSCREEN=
 if test "${1}" = "--screen"
 then
@@ -240,6 +264,15 @@ case "${ACTION}" in
 	#fi
 
    game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+
+	# --- Log newly generated modeline for future cleanup - start ---
+	NEW_MODE=$(xrandr | grep 'SR-1_' | awk '{print $1}' | tail -n1)
+
+	if [ -n "$NEW_MODE" ] && [ -n "$OUTPUT" ]; then
+		echo "$OUTPUT $NEW_MODE" > /tmp/switchres-last-resolution-state
+		echo "[batocera-resolution] Stored modeline state: $NEW_MODE on $OUTPUT" >> $log
+	fi
+	# --- Log newly generated modeline for future cleanup - end ---
 
     # Restore monitor and dotclock_min
     sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_MYZAR_ZFEbHVUE-MultiScreen
@@ -3,6 +3,29 @@
 log="/userdata/system/logs/display.log"
 mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
+# --- Clean up previous switchres modeline - start ---
+STATE_FILE="/tmp/switchres-last-resolution-state"
+
+if [ -f "$STATE_FILE" ]; then
+    read -r LAST_OUTPUT LAST_MODE < "$STATE_FILE"
+    CURRENT_MODE=$(xrandr --verbose | awk -v out="$LAST_OUTPUT" '
+        $0 ~ "^"out {found=1}
+        found && / connected/ {found=0}
+        found && /[0-9]+x[0-9]+/ && /\*/ {print $1; exit}
+    ')
+
+    if [ "$CURRENT_MODE" = "$LAST_MODE" ]; then
+        echo "[batocera-resolution] Skipping deletion of $LAST_MODE because it is currently active on $LAST_OUTPUT" >> $log
+    elif xrandr | grep -q "$LAST_MODE"; then
+        echo "[batocera-resolution] Deleting modeline $LAST_MODE from output $LAST_OUTPUT" >> $log
+        xrandr --delmode "$LAST_OUTPUT" "$LAST_MODE"
+    else
+        echo "[batocera-resolution] Previous modeline $LAST_MODE not found, skipping deletion" >> $log
+    fi
+
+    rm -f "$STATE_FILE"
+fi
+# --- Clean up previous switchres modeline - end ---
 
 PSCREEN=
 if test "${1}" = "--screen"
@@ -278,6 +301,15 @@ case "${ACTION}" in
 	#fi
 
     game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+
+	# --- Log newly generated modeline for future cleanup - start ---
+	NEW_MODE=$(xrandr | grep 'SR-1_' | awk '{print $1}' | tail -n1)
+
+	if [ -n "$NEW_MODE" ] && [ -n "$OUTPUT" ]; then
+		echo "$OUTPUT $NEW_MODE" > /tmp/switchres-last-resolution-state
+		echo "[batocera-resolution] Stored modeline state: $NEW_MODE on $OUTPUT" >> $log
+	fi
+	# --- Log newly generated modeline for future cleanup - end ---
 
     # Restore monitor and dotclock_min
     sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v42_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
@@ -3,6 +3,29 @@
 log="/userdata/system/logs/display.log"
 mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
+# --- Clean up previous switchres modeline - start ---
+STATE_FILE="/tmp/switchres-last-resolution-state"
+
+if [ -f "$STATE_FILE" ]; then
+    read -r LAST_OUTPUT LAST_MODE < "$STATE_FILE"
+    CURRENT_MODE=$(xrandr --verbose | awk -v out="$LAST_OUTPUT" '
+        $0 ~ "^"out {found=1}
+        found && / connected/ {found=0}
+        found && /[0-9]+x[0-9]+/ && /\*/ {print $1; exit}
+    ')
+
+    if [ "$CURRENT_MODE" = "$LAST_MODE" ]; then
+        echo "[batocera-resolution] Skipping deletion of $LAST_MODE because it is currently active on $LAST_OUTPUT" >> $log
+    elif xrandr | grep -q "$LAST_MODE"; then
+        echo "[batocera-resolution] Deleting modeline $LAST_MODE from output $LAST_OUTPUT" >> $log
+        xrandr --delmode "$LAST_OUTPUT" "$LAST_MODE"
+    else
+        echo "[batocera-resolution] Previous modeline $LAST_MODE not found, skipping deletion" >> $log
+    fi
+
+    rm -f "$STATE_FILE"
+fi
+# --- Clean up previous switchres modeline - end ---
 
 PSCREEN=
 if test "${1}" = "--screen"
@@ -277,6 +300,15 @@ case "${ACTION}" in
 	#fi
 
     game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
+
+	# --- Log newly generated modeline for future cleanup - start ---
+	NEW_MODE=$(xrandr | grep 'SR-1_' | awk '{print $1}' | tail -n1)
+
+	if [ -n "$NEW_MODE" ] && [ -n "$OUTPUT" ]; then
+		echo "$OUTPUT $NEW_MODE" > /tmp/switchres-last-resolution-state
+		echo "[batocera-resolution] Stored modeline state: $NEW_MODE on $OUTPUT" >> $log
+	fi
+	# --- Log newly generated modeline for future cleanup - end ---
 
     # Restore monitor and dotclock_min
     sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"


### PR DESCRIPTION
So I’ve been working on a pretty clever solution, I might say 😄

### ✅ What This Adds

---

#### 1. Track the Last Generated Modeline

```bash
STATE_FILE="/tmp/switchres-last-resolution-state"
```

This stores the most recently generated `switchres` modeline **along with the output** it was applied to.

Example:
```
DVI-I-1 SR-1_640x480@60.00i
```

- Allows us to **identify and delete exactly one mode** — the last one — instead of nuking all `SR-1_` modes.
- Stored in `/tmp` so it gets **automatically cleared on reboot** — no leftover junk.

---

#### 2. Safe Cleanup of the Previous Modeline

- Prevents `switchres` from leaving behind **unused modelines**.
- Ensures deletion is **safe**:
  - Skips deletion if the mode is still active (avoids `BadMatch` error).
- Cleans up **automatically on the next launch** of `batocera-resolution`, even if an emulator crashed.
- ✅ Works even when **only geometry (H size, H shift, V shift)** was changed — not just resolution or refresh rate.

---

#### 3. Logging the New Modeline After Creation

- Captures the most recent `SR-1_` modeline created by `switchres`.
- Ensures **only this one gets cleaned up next time**.
- Logs the result for **debugging and verification**.

---

### 🧹 What This Solves

- Prevents build-up of leftover modelines over time.
- Works reliably even across emulator crashes or forced exits.
- Enables `batocera-resolution` to **clean up after itself**, without relying on external shutdown hooks or `gameStop` scripts.