### PR TITLE
first_script.sh update for v42

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v42
+++ b/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v42
@@ -15,7 +15,7 @@ case $1 in
 
 		if [[ "$3" == "libretro" ]]; then
 			# Disable VSync for libretro emulators (RetroArch)
-			export vblank_mode=0
+			export vblank_mode=0 # TearFree removed — modesetting driver doesn't support it
 
 			if [[ "$2" == "fbneo" ]]; then
 				xrandr -display :0.0 -o [display_fbneo_rotation]
@@ -41,14 +41,6 @@ case $1 in
 
 		else
 			xrandr -display :0.0 -o [display_standalone_rotation]
-
-			# Placeholder for future tweaks (TearFree removed — modesetting doesn't support it)
-			if ([[ "$4" == "dolphin" ]]||[[ "$4" == "xemu" ]]||[[ "$2" == "windows" ]]|| \
-			     [[ "$2" == "wiiu" ]]||[[ "$2" == "psx" ]]||[[ "$2" == "psp" ]]|| \
-			     [[ "$2" == "ps2" ]]||[[ "$2" == "ps3" ]]||[[ "$2" == "switch" ]]); then
-				# No TearFree setting here — modesetting driver doesn't support it
-				:
-			fi
 		fi
 	;;
 
@@ -58,6 +50,6 @@ case $1 in
 		xrandr -display :0.0 -o [display_ES_rotation]
 		xrandr -display :0.0 --output [card_display] --mode "[es_resolution]"
 
-		# No need to unset vblank_mode — it's per-process and dies with the emulator
+		# No need to unset vblank_mode here — it's per-process and dies with the emulator
 	;;
 esac

--- a/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v42
+++ b/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v42
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Event hook script used by Batocera on game START or STOP
+
+# Set logfile location and filename (optional)
+logfile=/tmp/scriptlog.txt
+
+case $1 in
+	gameStart)
+
+		# Store emulator context
+		echo $2 > /dev/shm/sysname.txt
+		echo $3 > /dev/shm/emulator.txt
+		echo $4 > /dev/shm/core.txt
+		echo $5 > /dev/shm/args.txt
+
+		if [[ "$3" == "libretro" ]]; then
+			# Disable VSync for libretro emulators (RetroArch)
+			export vblank_mode=0
+
+			if [[ "$2" == "fbneo" ]]; then
+				xrandr -display :0.0 -o [display_fbneo_rotation]
+			else
+				xrandr -display :0.0 -o [display_libretro_rotation]
+			fi
+
+		elif [[ "$3" == "mame" ]]; then
+			# Disable VSync for standalone MAME
+			export vblank_mode=0
+
+			# Optional: manual resolution override
+			#MYZAR
+			#batocera-resolution setMode 640x480.60.00
+			#ZFEbHVUE
+			#batocera-resolution defineMode "640x480.60.0"
+			#batocera-resolution setMode_CVT "640x480.60.0"
+
+			xrandr -display :0.0 -o [display_mame_rotation]
+
+		elif [[ "$3" == "fpinball" ]]; then
+			xrandr -display :0.0 -o [display_ES_rotation]
+
+		else
+			xrandr -display :0.0 -o [display_standalone_rotation]
+
+			# Placeholder for future tweaks (TearFree removed — modesetting doesn't support it)
+			if ([[ "$4" == "dolphin" ]]||[[ "$4" == "xemu" ]]||[[ "$2" == "windows" ]]|| \
+			     [[ "$2" == "wiiu" ]]||[[ "$2" == "psx" ]]||[[ "$2" == "psp" ]]|| \
+			     [[ "$2" == "ps2" ]]||[[ "$2" == "ps3" ]]||[[ "$2" == "switch" ]]); then
+				# No TearFree setting here — modesetting driver doesn't support it
+				:
+			fi
+		fi
+	;;
+
+	gameStop)
+
+		# Restore rotation to ES default and resolution
+		xrandr -display :0.0 -o [display_ES_rotation]
+		xrandr -display :0.0 --output [card_display] --mode "[es_resolution]"
+
+		# No need to unset vblank_mode — it's per-process and dies with the emulator
+	;;
+esac


### PR DESCRIPTION
### 🛠️ Script Update: Event Hook Compatibility for Batocera v42 (modesetting)

This update modernizes the `start`/`stop` event hook script to align with Batocera v42's transition to the `modesetting` driver for AMD GPUs.

### ✅ Changes Made

- 🧹 **Removed legacy TearFree commands**   `xrandr --output --set TearFree ON/OFF` is no longer supported under the `modesetting` driver, so all references were safely removed.

- 🆕 **Added `vblank_mode=0` export**   This disables VSync at runtime for:
  - All **libretro** emulators (RetroArch cores)
  - **Standalone MAME**
  
  This allows reduced latency where needed, while preserving VSync globally for other emulators and platforms.

- 🎯 **Preserved display rotation logic**   Existing `xrandr -o` rotation assignments are untouched and continue to function for:
  - `fbneo`, `libretro`, `mame`, `fpinball`, and `standalone` cases.

- 🧼 **Removed obsolete conditional block for standalone emulators**   The placeholder `if` block for `dolphin`, `xemu`, `windows`, etc. was removed since TearFree is no longer applicable.

### 🧪 Notes

- No need to unset `vblank_mode` in `gameStop`, as it's process-local and automatically cleaned up.
- Compatible with Batocera v42 and later using the default AMD setup (`modesetting` driver).

This ensures clean compatibility with the latest video stack while reducing input latency for retro cores.