### PR TITLE
Fix black screen with radeon driver in v42

### DIFF
--- a/userdata/system/Batocera-CRT-Script/etc_configs/Monitors_config/20-radeon.conf_v42
+++ b/userdata/system/Batocera-CRT-Script/etc_configs/Monitors_config/20-radeon.conf_v42
@@ -1,0 +1,6 @@
+Section "OutputClass"
+     Identifier "Fix AMD Radeon Tearing"
+     Driver "radeon"
+     MatchDriver "radeon"
+     Option "TearFree" "false"
+EndSection


### PR DESCRIPTION
## Fix: Black screen / ES not starting when legacy `20-radeon.conf` forces DRI2 on AMD

### Summary
Batocera v42 moved AMD to the **modesetting DDX + DRI3** path by default. A leftover legacy file `/etc/X11/xorg.conf.d/20-radeon.conf` that forces **DRI2** (`Option "DRI" "2"`) causes display pipeline conflicts, leading to black screens and Xorg/driver errors when using the CRT Script.

### Background
- v42 defaults: **modesetting** (Xorg DDX) + **DRI3** + KMS pageflips.
- Old guides sometimes deploy `20-radeon.conf` that pins **radeon** DDX and sets `Option "DRI" "2"`.
- Mixing an expected DRI3 pipeline with an explicit DRI2 override breaks pageflips and 15 kHz modesets.