### PR TITLE
Switch to a single `20-modesetting.conf` for AMD v42

### DIFF
--- a/userdata/system/Batocera-CRT-Script/etc_configs/Monitors_config/20-modesetting.conf
+++ b/userdata/system/Batocera-CRT-Script/etc_configs/Monitors_config/20-modesetting.conf
@@ -1,0 +1,22 @@
+# /etc/X11/xorg.conf.d/20-modesetting.conf
+# Force the modesetting DDX for AMD GPUs, CRT-safe (15/25/31 kHz).
+# TearFree/VRR are kept OFF to preserve direct KMS pageflips.
+# (TearFree can insert a shadow framebuffer & blit path that blocks flips, adds latency,
+
+Section "OutputClass"
+    Identifier "AMD via modesetting (amdgpu)"
+    MatchDriver "amdgpu"               # Match AMD kernel driver
+    Driver "modesetting"               # Explicitly use modesetting DDX
+    Option "TearFree" "false"          # Keep direct pageflips; avoid TearFree shadow-FB blitting
+    Option "VariableRefresh" "false"   # VRR is irrelevant for fixed CRT timings
+    # No DRI option → stays on DRI3 by default
+EndSection
+
+Section "OutputClass"
+    Identifier "AMD via modesetting (radeon)"
+    MatchDriver "radeon"               # Match AMD kernel driver
+    Driver "modesetting"               # Explicitly use modesetting DDX
+    Option "TearFree" "false"          # Keep direct pageflips; avoid TearFree shadow-FB blitting
+    # No VariableRefresh here; not applicable with radeon
+    # No DRI option → stays on DRI3 by default
+EndSection


### PR DESCRIPTION
## Switch to a single `20-modesetting.conf` for AMD (amdgpu + radeon) on Batocera v42

## Summary
This PR adds **`/etc/X11/xorg.conf.d/20-modesetting.conf`** and deprecates the per-driver snippets `20-amdgpu.conf` and `20-radeon.conf` for the CRT Script on **Batocera v42**.

---

## Why 
v42 already runs AMD GPUs through **Xorg `modesetting` DDX + DRI3** by default (kernel drivers are still `amdgpu` or `radeon`).

---

## What it fixes
- Black screen / ES not starting when a legacy `20-radeon.conf` (from older script) **forces `Option "DRI" "2"`**, downgrading to DRI2 and breaking pageflips at 15 kHz.
- Intermittent pageflip/tearing quirks when TearFree/VRR options are picked up by a vendor DDX.
- Confusion about which AMD Xorg path is “correct” for v42 CRT use.

The new file **pins the intended stack** (modesetting DDX) for both AMD kernel drivers and keeps **TearFree/VRR off** for clean KMS pageflips at 15/25/31 kHz.

---

## Changes in this PR
1. **Add** `20-modesetting.conf` with two `OutputClass` blocks (one matches `amdgpu`, one matches `radeon`) that **explicitly select `modesetting`** and keep **TearFree/VRR off**. :contentReference[oaicite:0]{index=0}
2. **Stop relying on** `20-amdgpu.conf` and `20-radeon.conf` within the CRT Script (they remain in Batocera for non-CRT/LCD use, but the CRT Script no longer depends on them).

---

## Rationale (v42 AMD display stack)
- **Kernel driver:** `amdgpu` (GCN+) or `radeon` (TeraScale).
- **Xorg DDX (display driver):** **`modesetting`** by default in v42.
- **Render path:** glamor + Present + **DRI3**.
- **CRT requirements:** precise, low-frequency modelines and stable pageflips; **avoid “shadow-FB blit” paths** (e.g., TearFree) and **avoid DRI2**.

By explicitly selecting `modesetting` for both kernel drivers, we remove ambiguity and prevent legacy config from pulling Xorg onto a vendor DDX + DRI2.

## The new config (installed by the CRT Script v42)

```
# /etc/X11/xorg.conf.d/20-modesetting.conf
# Force the modesetting DDX for AMD GPUs, CRT-safe (15/25/31 kHz).
# TearFree/VRR are kept OFF to preserve direct KMS pageflips and stable low-freq timings.
# (TearFree can insert a shadow framebuffer & blit path that blocks flips, adds latency,
#  and can destabilize 15/25/31 kHz modelines.)

Section "OutputClass"
    Identifier "AMD via modesetting (amdgpu)"
    MatchDriver "amdgpu"               # Match AMD kernel driver
    Driver "modesetting"               # Explicitly use modesetting DDX
    Option "TearFree" "false"          # Keep direct pageflips; avoid TearFree shadow-FB blitting
    Option "VariableRefresh" "false"   # VRR is irrelevant for fixed CRT timings
    # No DRI option → stays on DRI3 by default
EndSection

Section "OutputClass"
    Identifier "AMD via modesetting (radeon)"
    MatchDriver "radeon"               # Match AMD kernel driver
    Driver "modesetting"               # Explicitly use modesetting DDX
    Option "TearFree" "false"          # Keep direct pageflips; avoid TearFree shadow-FB blitting
    # No VariableRefresh here; not applicable with radeon
    # No DRI option → stays on DRI3 by default
EndSection
```