### PR TITLE
Update emulationstation-standalone-v42_ZFEbHVUE-MultiScreen

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v42_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/emulationstation-standalone-v42_ZFEbHVUE-MultiScreen
@@ -172,7 +172,13 @@ while [ -e "${REBOOT_FLAG}" ]; do
 	    read screenoffset_x screenoffset_y <<< "$screenoffset_values"    
 	    display_rotate="$(/usr/bin/batocera-settings-get-master display.rotate)"
 	    read WIDTH HEIGHT PARTHZ <<< $(echo ${bootresolution} | awk -F'[x.]' '{print $1, $2, $3 "." $4}')
-	    RES="${WIDTH}x${HEIGHT}"
+	    
+        if [ $(( WIDTH % 10 % 2 )) -eq 0 ]; then
+	    	WIDTH=$(( WIDTH + 1 ))
+	    fi
+
+ 	    RES="${WIDTH}x${HEIGHT}"
+	    bootresolution="${RES}.${PARTHZ}"
 
 	    file="/userdata/system/es.arg.override"
 	    if [ -f "$file" ]; then


### PR DESCRIPTION
This update test if the  WIDTH is even or odd
If the WIDTH is even, we add +1 otherwise nothing is done.

and a new bootresolution and good parameters are put into batocera.conf and first_script too with good WIDTH HEIGHT and RES