### PR TITLE
Pre-X EDID-driven Xorg config; disable default VESA modes

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/boot-custom.sh
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/boot-custom.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Runs via /etc/init.d/S00bootcustom very early in boot
+# Generate /etc/X11/xorg.conf.d/15-crt-monitor.conf for CRT
+
+LOG="/var/log/crt_boot.log"
+CONF="/etc/X11/xorg.conf.d/15-crt-monitor.conf"
+MON10="/etc/X11/xorg.conf.d/10-monitor.conf"
+
+log(){ echo "[crt_boot] $*" >> "$LOG"; }
+
+main() {
+  # Run only on start
+  [ "$1" = "start" ] || { log "arg=$1, nothing to do"; return 0; }
+
+  # --- 1) Discover enabled output from 10-monitor.conf (no X needed) ---
+  OUT=""
+  if [ -f "$MON10" ]; then
+    OUT="$(awk '
+      BEGIN{s=0;id="";ign=0}
+      /^[[:space:]]*Section[[:space:]]+"Monitor"/ {s=1;id="";ign=0;next}
+      s && /^[[:space:]]*Identifier[[:space:]]+"/ {
+        match($0,/Identifier[[:space:]]*"[^\"]+"/)
+        if (RSTART) { id=substr($0,RSTART+length("Identifier \""),
+                  RLENGTH-length("Identifier \"")-1) }
+      }
+      s && /Option[[:space:]]+"Ignore"[[:space:]]+"true"/ { ign=1 }
+      s && /^[[:space:]]*EndSection/ { if (id!="" && ign==0) { print id; exit } s=0 }
+    ' "$MON10")"
+  fi
+
+  # Fallback to DRM sysfs if not found
+  if [ -z "$OUT" ]; then
+    for d in /sys/class/drm/card*-*; do
+      [ -e "$d/status" ] || continue
+      if [ "$(cat "$d/status" 2>/dev/null)" = "connected" ]; then
+        OUT="${d##*/}"; OUT="${OUT#card[0-9]-}"   # e.g. DVI-I-1
+        break
+      fi
+    done
+  fi
+  if [ -z "$OUT" ]; then
+    log "no enabled output found in $MON10 or DRM sysfs; abort"
+    return 0
+  fi
+
+  # --- 2) Choose EDID file with precedence: custom.bin > cmdline > first file ---
+  CMD="$(cat /proc/cmdline 2>/dev/null)"
+  EDID_FILE_CMD="$(printf '%s\n' "$CMD" | sed -n 's/.*drm\.edid_firmware=[^ :]\+:edid\/\([^ ]\+\).*/\1/p' | head -n1)"
+
+  if [ -f "/lib/firmware/edid/custom.bin" ]; then
+    EDID_BIN="/lib/firmware/edid/custom.bin"
+    EDID_SRC="custom.bin"
+  elif [ -n "$EDID_FILE_CMD" ] && [ -f "/lib/firmware/edid/$EDID_FILE_CMD" ]; then
+    EDID_BIN="/lib/firmware/edid/$EDID_FILE_CMD"
+    EDID_SRC="$EDID_FILE_CMD"
+  else
+    EDID_BIN="$(ls /lib/firmware/edid/*.bin 2>/dev/null | head -n1)"
+    EDID_SRC="$(basename "$EDID_BIN" 2>/dev/null)"
+  fi
+
+  # --- 3) Extract ranges from EDID (fallbacks if missing) ---
+  VR=""; HR=""
+  if [ -n "$EDID_BIN" ] && [ -f "$EDID_BIN" ]; then
+    LINE="$(edid-decode "$EDID_BIN" 2>/dev/null | grep -m1 'Display Range Limits' || true)"
+    VR="$(printf '%s\n' "$LINE" | sed -n 's/.* \([0-9][0-9]*\)-\([0-9][0-9]*\) Hz V.*/\1-\2/p')"
+    HR="$(printf '%s\n' "$LINE" | sed -n 's/.* \([0-9][0-9]*\(\.[0-9]\)\?\)-\([0-9][0-9]*\(\.[0-9]\)\?\) kHz H.*/\1-\3/p')"
+  fi
+  [ -n "$VR" ] || VR="49-65"
+  [ -n "$HR" ] || HR="15-16.5"
+
+  # --- 4) Write the Xorg snippet BEFORE X starts ---
+  mkdir -p /etc/X11/xorg.conf.d
+  cat > "$CONF" <<EOF
+Section "Monitor"
+    Identifier  "CRT"
+    VendorName  "BATOCERA_CRT_SCRIPT"
+    HorizSync   $HR
+    VertRefresh $VR
+    Option      "DPMS" "False"
+    Option      "DefaultModes" "False"
+EndSection
+
+Section "Device"
+    Identifier "modesetting-amd-crt-bind"
+    Driver "modesetting"
+    Option "Monitor-$OUT" "CRT"
+EndSection
+EOF
+
+  log "wrote $CONF (OUT=$OUT HS=$HR kHz VR=$VR Hz, EDID=$EDID_SRC)"
+  return 0
+}
+
+main "$@"


### PR DESCRIPTION
# Add pre-X CRT monitor binding & EDID-driven range limits (overlay-free)

## Summary

This PR introduces an **early-boot** mechanism that writes a minimal Xorg snippet to expose **only EDID/SwitchRes modes** on CRT setups, preventing Xorg from injecting default VESA modelines that are unsafe for 15 kHz displays.

Key features:

- Runs **before X** via `/etc/init.d/S00bootcustom` → `/boot/boot-custom.sh` (no late user-service race).
- Reads the **enabled output** from `10-monitor.conf` (the output **without** `Option "Ignore" "true"`), so it always targets the connector configured by the CRT script.
- Extracts **HorizSync/VertRefresh** from the active EDID using `edid-decode` (never hard-coded).
- Writes `/etc/X11/xorg.conf.d/15-crt-monitor.conf` with:
  - `Option "DefaultModes" "False"` to block default VESA modes,
  - `Option "DPMS" "False"`,
  - and a driver binding `Option "Monitor-<OUTPUT>" "CRT"` (modesetting).
- **EDID precedence**: `custom.bin` (user profile) → EDID named in kernel cmdline → first EDID `.bin` in `/lib/firmware/edid/`.
- Overlay-free: file is generated each boot; no need to persist the overlay.

This preserves EDID-declared timings and any **SwitchRes (SR-*)** modes while eliminating all other OS/driver-injected defaults that can break 15 kHz CRTs.

---

## Motivation

- On CRT installations, Xorg routinely adds a large set of default VESA modes that are **out of range** for 15 kHz.
- Relying on a post-X user service (or manual pruning via `xrandr`) is **too late**—the modes have already been probed and exposed.
- We need an **early**, deterministic, overlay-free approach that:
  - reflects the **actual EDID** (including user-provided `custom.bin`),
  - targets the **exact** output selected by the CRT script,
  - and cleanly disables default modes.

---

## What this PR changes

### 1) New early-boot generator

**File:** `/boot/boot-custom.sh` (executed by stock `/etc/init.d/S00bootcustom`)

Responsibilities:

1. **Discover the active output** from `10-monitor.conf`:
   - Parse the first `Section "Monitor"` that does **not** contain `Option "Ignore" "true"`.
   - Fallback: if not found, scan DRM sysfs (`/sys/class/drm/*/status`) for the first `connected` connector (still pre-X).
2. **Choose the EDID file** with explicit precedence:
   - `/lib/firmware/edid/custom.bin` *(highest priority; user-authored)*,
   - else the filename referenced in `/proc/cmdline` (`drm.edid_firmware=<OUT>:edid/<file.bin>`),
   - else the first `*.bin` under `/lib/firmware/edid/`.
3. **Extract range limits** via `edid-decode`:
   - Parse “Display Range Limits” to get `HorizSync` and `VertRefresh`.
   - Fallbacks used only if absent: `HorizSync 15-16.5`, `VertRefresh 49-65`.
4. **Write** `/etc/X11/xorg.conf.d/15-crt-monitor.conf` **before X starts**: ``` Section "Monitor" Identifier  "CRT" VendorName  "BATOCERA_CRT_SCRIPT"
       HorizSync   <from EDID>
       VertRefresh <from EDID>
       Option      "DPMS" "False"
       Option      "DefaultModes" "False"
   EndSection

   Section "Device" Identifier "modesetting-amd-crt-bind" Driver "modesetting" Option "Monitor-<OUTPUT>" "CRT" EndSection ```

5. **Log actions** to `/var/log/crt_boot.log`.

Outcome: when Xorg starts, it already sees DefaultModes "False" bound to the correct connector and constrained by EDID ranges, so it does not add the VESA pool. xrandr shows only the EDID + timing (and the active * timing), plus any later SR-* modes.

---

**Installation wiring (what we implemented recently)**

The installer / CRT script now:

1. Creates (or ensures) `10-monitor.conf` that **disables all outputs except one**. Example: ``` Section "Monitor" Identifier "DP-1" Option "Ignore" "true" EndSection

   Section "Monitor"
       Identifier "DVI-I-1"   # selected output (no Ignore)
   EndSection

   ```
2. **Drops** `/boot/boot-custom.sh` with the logic described above.

* No executable bit needed on VFAT; `S00bootcustom` invokes it via bash.

3. **(Optional)** The geometry tool / bootline already sets:

   ``` drm.edid_firmware=<OUT>:edid/custom.bin video=<OUT>:e ```

* This ensures **KMS/DRM** also uses the same EDID at kernel level. 
* Our generator **still** prioritizes `custom.bin`, so both sides are consistent.

4. **No user service** required (and intentionally avoided), because user services starts after X.

---

This PR ensures that on each boot, **before X starts**, we generate an Xorg config that binds the **selected CRT output** to EDID-accurate sync limits and **disables default modes**. Users get _only_ EDID + SwitchRes modes, no overlay, and clean 15 kHz-safe behavior. `custom.bin` always takes priority when present.