### PR TITLE
Limit `boot-custom.sh` to 15–25 kHz profiles

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
@@ -644,7 +644,7 @@ maybe_install_boot_custom_sh() {
   case "$choice_up" in
     NVIDIA_DRIVERS) proprietary_nvidia=1 ;;   # explicit proprietary
     NOUVEAU)        proprietary_nvidia=0 ;;   # explicit nouveau
-    *)  # unknown — use fallbacks
+    *)  # unknown - use fallbacks
         if [ -f /userdata/system/99-nvidia.conf ]; then
           proprietary_nvidia=1
         elif lsmod 2>/dev/null | grep -q '^nvidia'; then
@@ -678,6 +678,23 @@ maybe_install_boot_custom_sh() {
     box_hash
     return 0
   fi
+
+  # --- Skip for 31 kHz / multisync profiles ---------------------------------
+  # Only install boot-custom.sh for 15-25 kHz workflows.
+  # Profiles to SKIP:
+  # arcade_31 arcade_15_31 arcade_15_25_31 m2929 d9200 d9400 d9800 m3129
+  # pstar ms2930 r666b pc_31_120 pc_70_120 vesa_480 vesa_600 vesa_768 vesa_1024
+  local sel="${monitor_firmware:-}"
+  case "$sel" in
+    arcade_31|arcade_15_31|arcade_15_25_31|m2929|d9200|d9400|d9800|m3129| \
+    pstar|ms2930|r666b|pc_31_120|pc_70_120|vesa_480|vesa_600|vesa_768|vesa_1024)
+      echo "boot-custom: SKIP (profile=${sel})" >> "$LOG_FILE"
+      box_hash
+      box_center "Skipping ${BLUE}boot-custom.sh${NOCOLOR} (profile: ${sel})."
+      box_hash
+      return 0
+      ;;
+  esac
 
   # --- Proceed for AMD or NVIDIA (nouveau) -----------------------------------
   if [ ! -f "$SRC" ]; then
@@ -717,6 +734,7 @@ maybe_install_boot_custom_sh() {
   return 0
 }
 # ----------------------------------------------------------------------------- end
+
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Limit `boot-custom.sh` to 15–25 kHz profiles

## Summary
This PR keeps using `boot-custom.sh`, but only installs it when the user chooses a **15–25 kHz** CRT profile.   It will **not** install for **31 kHz** or **multisync** profiles.   This avoids nuking VESA modes (31Khz) on PC/multisync setups while keeping the intended behavior for 15 kHz users.

## Why
`boot-custom.sh` was installed for all profiles. On 31 kHz or multisync profiles nuked the VESA modes (31Khz). A behavior we don’t want.   We only need it for 15–25 kHz use.

## What changed
- Updated `maybe_install_boot_custom_sh()` to:
  - Check the selected monitor profile.
  - **Skip** installing `/boot/boot-custom.sh` for 31 kHz or multisync profiles.

## Profiles that now **SKIP** installing `boot-custom.sh`
- `arcade_31`
- `arcade_15_31`
- `arcade_15_25_31`
- `m2929`
- `d9200`
- `d9400`
- `d9800`
- `m3129`
- `pstar`
- `ms2930`
- `r666b`
- `pc_31_120`
- `pc_70_120`
- `vesa_480`
- `vesa_600`
- `vesa_768`
- `vesa_1024`

All other profiles continue as before.  
15 kHz and 15–25 kHz users still get `boot-custom.sh`.