### PR TITLE
Update Scaling & Overlays For Portable Systems

### DIFF
--- a/userdata/system/Batocera-CRT-Script/extra/overlays_overrides_script.sh
+++ b/userdata/system/Batocera-CRT-Script/extra/overlays_overrides_script.sh
@@ -2,37 +2,89 @@
 
 # Display initial message box with centered text.
 dialog --title "Important Information" \
-       --msgbox "\nThe tool installs override files for handheld systems and adds overlays. \
-\n\nIt will only work for 15khz profiles not limited to super resolutions. \
-\n\nWorks with the following profiles: \
-\n\n   - NTSC \
-\n   - generic_15 \
-\n   - arcade_15 \
-\n" 15 70
+       --msgbox "\nThis tool installs scaling override files (and optionally overlays) for handheld systems.\
+\n\nIt is intended for 15 kHz CRT profiles (including super resolutions).\
+\n\nKnown working profiles include:\
+\n   - NTSC\
+\n   - generic_15\
+\n   - arcade_15\
+\n" 16 70
 
-# Function for Install
-install_files() {
-    # Check for existing files
-    if [ -d "/userdata/system/configs/retroarch/config" ] || [ -d "/userdata/system/configs/retroarch/overlays" ]; then
-        dialog --title "Confirmation" \
-               --yesno "The installation has detected files already present.\nWould you like to overwrite them?" 10 50
-        response=$?
-        if [ $response -ne 0 ]; then
-            return  # Go back to the menu
-        fi
+# Paths
+SRC_CONFIG_DIR="/userdata/system/Batocera-CRT-Script/extra/config"
+SRC_OVERLAY_BORDERS_DIR="/userdata/system/Batocera-CRT-Script/extra/overlays/borders"
+
+DEST_CONFIG_DIR="/userdata/system/configs/retroarch/config"
+DEST_OVERLAY_BORDERS_DIR="/userdata/system/configs/retroarch/overlays/borders"
+
+# batocera.conf tweak backup/restore (so Uninstall can revert cleanly)
+BATOCERA_CONF="/userdata/system/batocera.conf"
+BACKUP_DIR="/userdata/system/Batocera-CRT-Script/extra/.scaling_tool_backup"
+BATOCERA_CONF_BACKUP_FILE="$BACKUP_DIR/batocera.conf.keys.backup"
+
+# Save original values for keys we modify in batocera.conf.
+# We only create this backup once (on first install), so Uninstall can restore the user's original settings.
+backup_batocera_conf_tweaks() {
+    local keys=("lynx.core" "lynx.emulator" "nds.melonds_screen_layout" "nds.screens_layout")
+
+    # Don't overwrite an existing backup (keeps the true original state)
+    if [ -f "$BATOCERA_CONF_BACKUP_FILE" ]; then
+        return 0
     fi
-    
-    # Create target directories if they don't exist
-    mkdir -p /userdata/system/configs/retroarch/config
-    mkdir -p /userdata/system/configs/retroarch/overlays
 
-    # Copy files and set permissions
-    cp -r /userdata/system/Batocera-CRT-Script/extra/config/. /userdata/system/configs/retroarch/config/
-    cp -r /userdata/system/Batocera-CRT-Script/extra/overlays/. /userdata/system/configs/retroarch/overlays/
-    chmod -R u+rw,go+rw /userdata/system/configs/retroarch/config/
-    chmod -R u+rw,go+rw /userdata/system/configs/retroarch/overlays/
+    mkdir -p "$BACKUP_DIR" 2>/dev/null
 
-    # Edit batocera.conf
+    {
+        echo "# Batocera-CRT-Script Scaling Tool - batocera.conf key backup"
+        echo "# Created: $(date)"
+        for k in "${keys[@]}"; do
+            if grep -q "^${k}=" "$BATOCERA_CONF" 2>/dev/null; then
+                # Store the *value* only (can include spaces)
+                local v
+                v="$(grep -m1 "^${k}=" "$BATOCERA_CONF" | sed "s/^${k}=//")"
+                printf '%s|present|%s\n' "$k" "$v"
+            else
+                printf '%s|absent|\n' "$k"
+            fi
+        done
+    } > "$BATOCERA_CONF_BACKUP_FILE"
+}
+
+restore_batocera_conf_tweaks() {
+    local keys=("lynx.core" "lynx.emulator" "nds.melonds_screen_layout" "nds.screens_layout")
+
+    # If we have a real backup, restore exactly.
+    if [ -f "$BATOCERA_CONF_BACKUP_FILE" ]; then
+        while IFS='|' read -r key status value; do
+            # Skip comments/empty lines
+            [ -z "$key" ] && continue
+            [[ "$key" == \#* ]] && continue
+
+            # Remove any existing lines for the key (including duplicates)
+            sed -i "/^${key}=.*/d" "$BATOCERA_CONF"
+
+            if [ "$status" = "present" ]; then
+                echo "${key}=${value}" >> "$BATOCERA_CONF"
+            fi
+        done < "$BATOCERA_CONF_BACKUP_FILE"
+
+        # Backup is one-time-use: after a successful restore, remove it
+        rm -f "$BATOCERA_CONF_BACKUP_FILE" 2>/dev/null
+
+        return 0
+    fi
+
+    # No backup found: do a safe best-effort revert (only remove the exact values we enforce)
+    sed -i '/^lynx.core=handy$/d' "$BATOCERA_CONF"
+    sed -i '/^lynx.emulator=libretro$/d' "$BATOCERA_CONF"
+    sed -i '/^nds.melonds_screen_layout=Top Only$/d' "$BATOCERA_CONF"
+    sed -i '/^nds.screens_layout=top only$/d' "$BATOCERA_CONF"
+
+    return 0
+}
+
+# Apply required batocera.conf tweaks (used by both install methods)
+apply_batocera_conf_tweaks() {
     CONFIG_FILE="/userdata/system/batocera.conf"
 
     # Remove duplicates of lynx lines if they exist
@@ -68,17 +120,74 @@ install_files() {
     else
         echo "nds.screens_layout=top only" >> "$CONFIG_FILE"
     fi
+}
 
-    dialog --title "Success" --msgbox "Files have been installed successfully." 10 50
+# Function: Install Overlays & Scaling files
+install_overlays_and_scaling() {
+    # Check for existing files
+    if [ -d "$DEST_CONFIG_DIR" ] || [ -d "$DEST_OVERLAY_BORDERS_DIR" ]; then
+        dialog --title "Confirmation" \
+               --yesno "Existing RetroArch scaling/overlay files were detected.\n\nOverwrite the existing files?" 11 60
+        response=$?
+        if [ $response -ne 0 ]; then
+            return
+        fi
+    fi
+
+    # Create target directories if they don't exist
+    mkdir -p "$DEST_CONFIG_DIR"
+    mkdir -p "$DEST_OVERLAY_BORDERS_DIR"
+
+    # Copy scaling override files and set permissions
+    cp -r "$SRC_CONFIG_DIR/." "$DEST_CONFIG_DIR/"
+    chmod -R u+rw,go+rw "$DEST_CONFIG_DIR/"
+
+    # Copy overlays (borders only) and set permissions
+    cp -r "$SRC_OVERLAY_BORDERS_DIR/." "$DEST_OVERLAY_BORDERS_DIR/"
+    chmod -R u+rw,go+rw "$(dirname "$DEST_OVERLAY_BORDERS_DIR")/"
+
+    # Ensure Uninstall can restore the user's original batocera.conf values
+    backup_batocera_conf_tweaks
+    apply_batocera_conf_tweaks
+
+    dialog --title "Success" --msgbox "Overlays and scaling files have been installed successfully." 10 65
+}
+
+# Function: Install Scaling files only (NO Overlays)
+install_scaling_only() {
+    if [ -d "$DEST_CONFIG_DIR" ]; then
+        dialog --title "Confirmation" \
+               --yesno "Existing RetroArch scaling override files were detected.\n\nOverwrite the existing files?" 11 62
+        response=$?
+        if [ $response -ne 0 ]; then
+            return
+        fi
+    fi
+
+    mkdir -p "$DEST_CONFIG_DIR"
+
+    cp -r "$SRC_CONFIG_DIR/." "$DEST_CONFIG_DIR/"
+    chmod -R u+rw,go+rw "$DEST_CONFIG_DIR/"
+
+    # Ensure Uninstall can restore the user's original batocera.conf values
+    backup_batocera_conf_tweaks
+    apply_batocera_conf_tweaks
+
+    dialog --title "Success" --msgbox "Scaling files have been installed successfully (no overlays were installed)." 10 72
 }
 
 # Function for Uninstall
 uninstall_files() {
     dialog --title "Confirmation" \
-           --yesno "This will uninstall the override and overlays files.\nWould you like to remove them?" 10 50
+           --yesno "This will uninstall scaling override files and (if present) the handheld overlays.\n\nContinue?" 11 70
     response=$?
     if [ $response -ne 0 ]; then
         return  # Go back to the menu
+    fi
+
+    local had_backup=0
+    if [ -f "$BATOCERA_CONF_BACKUP_FILE" ]; then
+        had_backup=1
     fi
 
     # Remove specified folders from the config directory
@@ -94,8 +203,8 @@ uninstall_files() {
            "$CONFIG_DIR/mGBA" \
            "$CONFIG_DIR/VBA-M"
 
-    # Remove specified folders from the overlays/borders directory
-    OVERLAY_BORDERS="/userdata/system/configs/retroarch/overlays/borders"
+    # Remove specified folders from the overlays/borders directory (if present)
+    OVERLAY_BORDERS="$DEST_OVERLAY_BORDERS_DIR"
     rm -rf "$OVERLAY_BORDERS/Arduboy" \
            "$OVERLAY_BORDERS/Assets Transparancy" \
            "$OVERLAY_BORDERS/Atari Lynx Horizontal" \
@@ -107,23 +216,35 @@ uninstall_files() {
            "$OVERLAY_BORDERS/Pico-8" \
            "$OVERLAY_BORDERS/Super GameBoy"
 
-    dialog --title "Success" --msgbox "Files have been uninstalled successfully." 10 50
+    # Revert batocera.conf tweaks
+    restore_batocera_conf_tweaks
+
+    if [ $had_backup -eq 1 ]; then
+        dialog --title "Success" --msgbox "Files have been uninstalled successfully.\n\nBatocera.conf settings were restored to your original values." 12 70
+    else
+        dialog --title "Success" --msgbox "Files have been uninstalled successfully.\n\nNote: No batocera.conf backup was found, so a safe best-effort revert was used (it only removes the exact values this tool sets)." 14 72
+    fi
 }
 
 # Infinite loop for menu selection
 while true; do
-    choice=$(dialog --title "Overlay & Override files Selection" \
+    choice=$(dialog --title "Overlays & Scaling Files" \
                     --clear \
                     --nocancel \
-                    --menu "Overlay & Override Install / Uninstall" 20 80 10 \
-                    "Install" "Install overlay & override files" \
-                    "Uninstall" "Removes overlay & override files" \
+                    --no-tags \
+                    --menu "Install / Uninstall" 21 85 12 \
+                    "Install_All" "Install Overlays & Scaling files" \
+                    "Install_Scaling" "Install Scaling files only (NO Overlays)" \
+                    "Uninstall" "Uninstall Scaling files (and Overlays if installed)" \
                     "Quit" "Exit back to Emulation Station" \
                     3>&1 1>&2 2>&3)
     
     case $choice in
-        Install)
-            install_files
+        Install_All)
+            install_overlays_and_scaling
+            ;;
+        Install_Scaling)
+            install_scaling_only
             ;;
         Uninstall)
             uninstall_files


### PR DESCRIPTION
Update Scaling & Overlays For Portable Systems Tool


Overlays/Scaling installer: add “Scaling only” mode and make uninstall revert `batocera.conf` tweaks

## Summary
This updates the Overlays & Scaling Files installer to support a scaling-only install path (no overlays) and improves uninstall so it properly handles both install types and restores any `batocera.conf` changes made by the installer.

## What changed
### UI / Menu
- Renamed menu entry:
  - “Install overlay & override files” -> “Install Overlays & Scaling files”
- Added new menu entry:
  - “Install Scaling files only (NO Overlays)”

### Install behavior
- “Install Overlays & Scaling files”
  - Installs scaling override files from:
    - `/userdata/system/Batocera-CRT-Script/extra/config` -> `/userdata/system/configs/retroarch/config`
  - Installs borders overlays from:
    - `/userdata/system/Batocera-CRT-Script/extra/overlays/borders` -> `/userdata/system/configs/retroarch/overlays/borders`
  - Applies known `batocera.conf` tweaks (Lynx + NDS)

- “Install Scaling files only (NO Overlays)”
  - Installs ONLY scaling override files (same config path as above)
  - Does NOT install overlays
  - Applies the same `batocera.conf` tweaks (Lynx + NDS)

### Uninstall behavior
- Uninstall now supports BOTH install types:
  - Removes the known override folders under:
    - `/userdata/system/configs/retroarch/config`
  - Removes overlay border folders if present under:
    - `/userdata/system/configs/retroarch/overlays/borders`
- Uninstall now also reverts `batocera.conf` changes made by this tool:
  - Installer creates a backup of the affected keys before applying tweaks
  - Uninstall restores original values (or removes keys if they were originally absent)

## batocera.conf keys tracked
- `lynx.core`
- `lynx.emulator`
- `nds.melonds_screen_layout`
- `nds.screens_layout`

Backup file:
- `/userdata/system/Batocera-CRT-Script/extra/.scaling_tool_backup/batocera.conf.keys.backup`

## Why
- Some users only want scaling overrides without overlays (borders not desired).
- Uninstall should fully revert system changes, including `batocera.conf` tweaks, to avoid leaving unexpected defaults behind.


## Notes / Compatibility
- If a user runs Uninstall without an existing backup file, uninstall performs a safe best-effort revert only for the values this tool sets.