### PR TITLE
Update Batocera-CRT-Script-v43.sh Problem detection APU

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -2566,7 +2566,7 @@ if ([ "$TYPE_OF_CARD" == "NVIDIA" ] && [ "$Drivers_Nvidia_CHOICE" == "Nvidia_Dri
  
  
     # Parity must follow the display engine (Calamity): DCN => even, DCE/unknown => off
-    if [ "$TYPE_OF_CARD" = "AMD/ATI" ] && [ "${DISPLAY_ENGINE:-NONE}" = "DCN" ]; then
+    if [ "$TYPE_OF_CARD" = "AMD/ATI" ] && [ "${DISPLAY_ENGINE:-NONE}" = "DCN" ] && [ "$AMD_IS_APU" = "1" ]; then
        IFE=1
     else
        IFE=0


### PR DESCRIPTION
## Summary

`interlace_force_even=1` is incorrectly applied to discrete AMD DCN GPUs (e.g. RX 6400 / Navi 24), causing vertical instability on CRT displays.

## Problem

The script correctly detects whether a GPU uses the DCN (Display Core Next) display engine. However, the parity decision at line ~2568 sets `IFE=1` for **all** AMD DCN GPUs:

```bash
if [ "$TYPE_OF_CARD" = "AMD/ATI" ] && [ "${DISPLAY_ENGINE:-NONE}" = "DCN" ]; then
    IFE=1
```

This is incorrect. The rule `DCN => interlace_force_even=1` only applies to **AMD APUs** (integrated graphics). Discrete DCN GPUs such as the RX 6400 (Navi 24 / CHIP_BEIGE_GOBY) require `interlace_force_even=0`, otherwise the CRT image trembles vertically.

Ironically, this contradicts a comment already present in the same script at line ~1958:

```bash
# Display engine from multiple sources; do NOT equate DCN with APU.
```

## Affected hardware

Any discrete AMD RDNA2 GPU using the DCN display engine, for example:
* RX 6400 (Navi 24, device ID 0x743F)
* RX 6500 XT (Navi 24, device ID 0x743F)

These cards are correctly detected as `AMD_IS_APU=0` by the APU detection logic, but still receive `IFE=1` due to the incorrect condition.

## Fix

Add `AMD_IS_APU=1` as an additional condition:

Before (buggy):
```bash
if [ "$TYPE_OF_CARD" = "AMD/ATI" ] && [ "${DISPLAY_ENGINE:-NONE}" = "DCN" ]; then
    IFE=1
else
    IFE=0
fi
```

After (fixed):
```bash
if [ "$TYPE_OF_CARD" = "AMD/ATI" ] && [ "${DISPLAY_ENGINE:-NONE}" = "DCN" ] && [ "$AMD_IS_APU" = "1" ]; then
    IFE=1
else
    IFE=0
fi
```

This ensures that:
* AMD APU + DCN → `interlace_force_even=1` (correct)
* AMD discrete GPU + DCN → `interlace_force_even=0` (correct)

## Additional notes

* Tested on RX 6400 (Navi 24) under Batocera v43-dev with a 15kHz CRT on DP-1.
* With `IFE=1`, the CRT image trembles vertically. With `IFE=0`, the image is stable.
* The `AMD_IS_APU` variable is already correctly set to `0` for the RX 6400 by the existing APU detection logic.