### PR TITLE
Restored the missing helper functions used by setMode_CVT

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
@@ -267,6 +267,46 @@ fi
 ACTION=$1
 shift
 
+# --- helpers: whitelist-aware mode selection (videomodes.conf) ---
+is_mode_in_videomodes_conf() {
+  local m="$1" f
+  for f in /userdata/system/videomodes.conf /userdata/system/configs/videomodes.conf; do
+    [ -s "$f" ] || continue
+    awk -v M="$m" 'NF && $0 !~ /^[[:space:]]*#/ { if ($0==M) { found=1; exit } } END { exit !found }' "$f"
+    if [ $? -eq 0 ]; then return 0; fi
+  done
+  return 1
+}
+
+_parse_wxh_rr() {
+  local s="$1"
+  if [[ "$s" =~ ^([0-9]+)x([0-9]+)\.([0-9.]+)$ ]]; then
+    echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]} ${BASH_REMATCH[3]}"
+    return 0
+  fi
+  return 1
+}
+
+_set_mode_from_videomodes_conf() {
+  local token="$1" out="${PSCREEN}"
+  local W H RR
+  if read -r W H RR < <(_parse_wxh_rr "$token"); then
+    xrandr --output "$out" --mode "${W}x${H}" --rate "$RR" 2>/dev/null && return 0
+    xrandr --output "$out" --mode "${W}x${H}" 2>/dev/null && return 0
+    if command -v switchres >/dev/null 2>&1; then
+      switchres -k -f "${W}x${H}@${RR}" >/dev/null 2>&1 || true
+      xrandr --output "$out" --mode "${W}x${H}" --rate "$RR" 2>/dev/null && return 0
+    fi
+    return 1
+  fi
+  if [[ "$token" =~ ^([0-9]+)x([0-9]+)$ ]]; then
+    xrandr --output "$out" --mode "$token"
+    return $?
+  fi
+  return 1
+}
+
+
 case "${ACTION}" in
     "listModes")
         # STRICT: only list modes explicitly present in videomodes.conf


### PR DESCRIPTION
Restored the missing helper functions used by setMode_CVT:

- is_mode_in_videomodes_conf

- _parse_wxh_rr

- _set_mode_from_videomodes_conf