### PR TITLE
Add CRT 240p layout installer integration to Carbon theme

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
@@ -321,6 +321,7 @@ FILES_TO_HANDLE=(
   "/boot/EFI/batocera/syslinux.cfg"
   "/boot/EFI/BOOT/syslinux.cfg"
   "/userdata/system/batocera.conf"
+  "/usr/share/emulationstation/themes/es-theme-carbon/theme.xml"
 )
 
 # Extra files to delete on restore (if present)
@@ -341,6 +342,7 @@ EXTRA_DELETE_FILES=(
   "/boot/boot/overlay"
   "/boot/batocera-boot.conf.bak"
   "/boot/boot-custom.sh"
+  "/usr/share/emulationstation/themes/es-theme-carbon/layouts/crt240p.xml"
 )
 
 # Directories whose syslinux.cfg.bak / syslinux.cfg.initial should be purged if present
@@ -4038,6 +4040,55 @@ cp -a /userdata/system/Batocera-CRT-Script/Geometry_modeline/crt/ /userdata/roms
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt.cfg /userdata/system/configs/emulationstation/es_systems_crt.cfg
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.png /usr/share/emulationstation/themes/es-theme-carbon/art/consoles/CRT.png
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.svg /usr/share/emulationstation/themes/es-theme-carbon/art/logos/CRT.svg
+
+#######################################################################################
+# Patch CRT 240p layout into stock Carbon theme
+#######################################################################################
+THEME_DIR="/usr/share/emulationstation/themes/es-theme-carbon"
+
+# Copy CRT 240p layout file
+cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/crt240p.xml \
+   "${THEME_DIR}/layouts/crt240p.xml"
+
+# Inject CRT 240p subset block into theme.xml (after optimizesmallscreens block)
+if ! grep -q 'name="crt240p"' "${THEME_DIR}/theme.xml"; then
+  sed -i '/name="optimizesmallscreens"/,/<\/subset>/{
+    /<\/subset>/a\
+\
+  <!-- CRT 240p optimization -->\
+  <subset name="crt240p" displayName="CRT 240p Mode">\
+    <include name="on" displayName="On">./layouts/crt240p.xml<\/include>\
+    <include name="off" displayName="Off"\/>\
+  <\/subset>
+  }' "${THEME_DIR}/theme.xml"
+fi
+
+#######################################################################################
+# Set CRT 240p theme preference based on boot resolution
+#######################################################################################
+ES_SETTINGS="/userdata/system/configs/emulationstation/es_settings.cfg"
+
+if [ "$V_RES_EDID" = "240" ]; then
+  CRT240P_VALUE="on"
+else
+  CRT240P_VALUE="off"
+fi
+
+if [ -f "$ES_SETTINGS" ]; then
+  if grep -q 'subset.es-theme-carbon.crt240p' "$ES_SETTINGS"; then
+    sed -i "s|subset.es-theme-carbon.crt240p\" value=\"[^\"]*\"|subset.es-theme-carbon.crt240p\" value=\"${CRT240P_VALUE}\"|" "$ES_SETTINGS"
+  else
+    sed -i "/<\/config>/i\\	<string name=\"subset.es-theme-carbon.crt240p\" value=\"${CRT240P_VALUE}\" />" "$ES_SETTINGS"
+  fi
+else
+  cat > "$ES_SETTINGS" <<ESEOF
+<?xml version="1.0"?>
+<config>
+	<string name="subset.es-theme-carbon.crt240p" value="${CRT240P_VALUE}" />
+</config>
+ESEOF
+fi
+
 chmod 755 /userdata/roms/crt/es_adjust_tool.sh
 chmod 755 /userdata/roms/crt/geometry.sh
 chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_tool.sh

--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -321,6 +321,7 @@ FILES_TO_HANDLE=(
   "/boot/EFI/batocera/syslinux.cfg"
   "/boot/EFI/BOOT/syslinux.cfg"
   "/userdata/system/batocera.conf"
+  "/usr/share/emulationstation/themes/es-theme-carbon/theme.xml"
 )
 
 # Extra files to delete on restore (if present)
@@ -341,6 +342,7 @@ EXTRA_DELETE_FILES=(
   "/boot/boot/overlay"
   "/boot/batocera-boot.conf.bak"
   "/boot/boot-custom.sh"
+  "/usr/share/emulationstation/themes/es-theme-carbon/layouts/crt240p.xml"
 )
 
 # Directories whose syslinux.cfg.bak / syslinux.cfg.initial should be purged if present
@@ -4088,6 +4090,55 @@ cp -a /userdata/system/Batocera-CRT-Script/Geometry_modeline/crt/ /userdata/roms
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt.cfg /userdata/system/configs/emulationstation/es_systems_crt.cfg
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.png /usr/share/emulationstation/themes/es-theme-carbon/art/consoles/CRT.png
 cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.svg /usr/share/emulationstation/themes/es-theme-carbon/art/logos/CRT.svg
+
+#######################################################################################
+# Patch CRT 240p layout into stock Carbon theme
+#######################################################################################
+THEME_DIR="/usr/share/emulationstation/themes/es-theme-carbon"
+
+# Copy CRT 240p layout file
+cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/crt240p.xml \
+   "${THEME_DIR}/layouts/crt240p.xml"
+
+# Inject CRT 240p subset block into theme.xml (after optimizesmallscreens block)
+if ! grep -q 'name="crt240p"' "${THEME_DIR}/theme.xml"; then
+  sed -i '/name="optimizesmallscreens"/,/<\/subset>/{
+    /<\/subset>/a\
+\
+  <!-- CRT 240p optimization -->\
+  <subset name="crt240p" displayName="CRT 240p Mode">\
+    <include name="on" displayName="On">./layouts/crt240p.xml<\/include>\
+    <include name="off" displayName="Off"\/>\
+  <\/subset>
+  }' "${THEME_DIR}/theme.xml"
+fi
+
+#######################################################################################
+# Set CRT 240p theme preference based on boot resolution
+#######################################################################################
+ES_SETTINGS="/userdata/system/configs/emulationstation/es_settings.cfg"
+
+if [ "$V_RES_EDID" = "240" ]; then
+  CRT240P_VALUE="on"
+else
+  CRT240P_VALUE="off"
+fi
+
+if [ -f "$ES_SETTINGS" ]; then
+  if grep -q 'subset.es-theme-carbon.crt240p' "$ES_SETTINGS"; then
+    sed -i "s|subset.es-theme-carbon.crt240p\" value=\"[^\"]*\"|subset.es-theme-carbon.crt240p\" value=\"${CRT240P_VALUE}\"|" "$ES_SETTINGS"
+  else
+    sed -i "/<\/config>/i\\	<string name=\"subset.es-theme-carbon.crt240p\" value=\"${CRT240P_VALUE}\" />" "$ES_SETTINGS"
+  fi
+else
+  cat > "$ES_SETTINGS" <<ESEOF
+<?xml version="1.0"?>
+<config>
+	<string name="subset.es-theme-carbon.crt240p" value="${CRT240P_VALUE}" />
+</config>
+ESEOF
+fi
+
 chmod 755 /userdata/roms/crt/es_adjust_tool.sh
 chmod 755 /userdata/roms/crt/geometry.sh
 chmod 755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_tool.sh

--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/crt240p.xml
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/crt240p.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CRT 240p Layout (320x240)
+  Optimized for 15kHz CRT TVs viewed at 3-6 feet.
+  All font sizes target 12-16px at 240p for phosphor readability.
+-->
+<theme defaultView="gamecarousel">
+  <formatVersion>7</formatVersion>
+
+  <!-- MENU -->
+  <view name="menu">
+    <menuText name="menutitle">
+      <fontSize>0.044</fontSize>
+    </menuText>
+    <menuText name="menutext">
+      <fontSize>0.050</fontSize>
+    </menuText>
+    <menuText name="menufooter">
+      <fontSize>0.042</fontSize>
+    </menuText>
+    <menuTextSmall name="menutextsmall">
+      <fontSize>0.042</fontSize>
+    </menuTextSmall>
+    <menuGroup name="menugroup">
+      <fontSize>0.042</fontSize>
+    </menuGroup>
+  </view>
+
+  <!-- SCREEN (status bar) — keep clock, battery, controller activity -->
+  <view name="screen">
+    <text name="clock">
+      <fontSize>0.040</fontSize>
+      <pos>0.85 0.94</pos>
+      <size>0.14 0.058</size>
+    </text>
+    <controllerActivity name="controllerActivity">
+      <pos>0.015 0.028</pos>
+      <size>0.28 0.055</size>
+      <itemSpacing>0.006</itemSpacing>
+    </controllerActivity>
+  </view>
+
+  <!-- SYSTEM VIEW -->
+  <view name="system">
+    <carousel name="systemcarousel">
+      <color>FFFFFF00</color>
+      <colorEnd>FFFFFF00</colorEnd>
+    </carousel>
+    <text name="systemInfo">
+      <fontSize>0.058</fontSize>
+      <pos>0.05 0.75</pos>
+      <size>0.90 0.14</size>
+      <color>D0D0D0</color>
+      <alignment>center</alignment>
+    </text>
+    <text name="logoText">
+      <fontSize>0.075</fontSize>
+      <pos>0.02 0.08</pos>
+      <size>0.96 0.18</size>
+    </text>
+    <clock name="clock">
+      <fontSize>0.050</fontSize>
+    </clock>
+    <image name="ControllerOverlay" extra="true">
+      <pos>0.5 0.22</pos>
+      <maxSize>0.35 0.28</maxSize>
+    </image>
+    <image name="carousel-shadow" extra="true">
+      <visible>false</visible>
+    </image>
+    <image name="carousel-inner" extra="true">
+      <visible>false</visible>
+    </image>
+    <image name="CenterFade" extra="true">
+      <visible>false</visible>
+    </image>
+    <image name="BottomBar-shadow" extra="true">
+      <visible>false</visible>
+    </image>
+  </view>
+  <feature supported="manufacturer">
+    <view name="system">
+      <text name="manufacturerName" extra="static">
+        <fontSize>0.075</fontSize>
+        <pos>0.02 0.08</pos>
+        <size>0.96 0.10</size>
+      </text>
+      <text name="fullName" extra="true">
+        <fontSize>0.050</fontSize>
+        <pos>0.03 0.18</pos>
+        <size>0.94 0.08</size>
+      </text>
+      <text name="releaseYyear" extra="true">
+        <fontSize>0.050</fontSize>
+        <pos>0.03 0.27</pos>
+        <size>0.94 0.05</size>
+      </text>
+    </view>
+  </feature>
+
+  <!-- HELP SYSTEM -->
+  <view name="system, basic, detailed, grid, gamecarousel">
+    <helpsystem name="help">
+      <fontSize>0.042</fontSize>
+    </helpsystem>
+  </view>
+
+  <!-- COMMON (top bar for game views) -->
+  <view name="basic, detailed, grid, gamecarousel">
+    <text name="logoText">
+      <fontSize>0.067</fontSize>
+      <pos>0.02 0.01</pos>
+      <size>0.96 0.12</size>
+    </text>
+    <image name="logo">
+      <maxSize>0.30 0.11</maxSize>
+    </image>
+    <text name="folderpath">
+      <fontSize>0.042</fontSize>
+      <pos>0.05 0.12</pos>
+      <size>0.90 0.03</size>
+    </text>
+    <text name="filterInfo" extra="true">
+      <fontSize>0.042</fontSize>
+      <pos>0.05 0.12</pos>
+      <size>0.90 0.03</size>
+    </text>
+    <!-- Hide decorative overlays -->
+    <image name="top-shadow" extra="true">
+      <visible>false</visible>
+    </image>
+    <image name="bottom-shadow" extra="true">
+      <visible>false</visible>
+    </image>
+    <image name="consolebk" extra="true">
+      <visible>false</visible>
+    </image>
+    <image name="ControllerOverlay" extra="true">
+      <visible>false</visible>
+    </image>
+  </view>
+
+  <!-- BASIC VIEW — full-width text list -->
+  <view name="basic">
+    <textlist name="gamelist">
+      <pos>0.02 0.16</pos>
+      <size>0.96 0.77</size>
+      <fontSize>0.050</fontSize>
+      <lines>12</lines>
+      <horizontalMargin>0.005</horizontalMargin>
+    </textlist>
+  </view>
+
+  <!-- DETAILED VIEW — font size overrides only, stock layout with metadata -->
+  <view name="detailed">
+    <textlist name="gamelist">
+      <fontSize>0.050</fontSize>
+    </textlist>
+    <text name="md_description">
+      <fontSize>0.042</fontSize>
+    </text>
+    <text name="md_developer, md_genre, md_players">
+      <fontSize>0.042</fontSize>
+    </text>
+    <text name="md_lbl_players, md_lbl_releasedate, md_lbl_developer, md_lbl_publisher, md_lbl_genre, md_lbl_rating, md_lbl_playcount, md_lbl_lastplayed">
+      <fontSize>0.042</fontSize>
+    </text>
+    <datetime name="md_releasedate, md_lastplayed">
+      <fontSize>0.042</fontSize>
+    </datetime>
+  </view>
+
+  <!-- GRID VIEW — single item with large text fallback -->
+  <view name="grid">
+    <imagegrid name="gamegrid">
+      <autoLayout>1 1</autoLayout>
+      <pos>0.02 0.16</pos>
+      <size>0.96 0.77</size>
+      <scrollDirection>horizontal</scrollDirection>
+      <centerSelection>true</centerSelection>
+      <scrollLoop>true</scrollLoop>
+    </imagegrid>
+    <text name="gridtile">
+      <fontSize>0.050</fontSize>
+    </text>
+    <gridtile name="default">
+      <backgroundCornerSize>0 0</backgroundCornerSize>
+      <padding>0 0</padding>
+    </gridtile>
+    <gridtile name="selected">
+      <backgroundCornerSize>0 0</backgroundCornerSize>
+      <padding>0 0</padding>
+      <backgroundColor>00000000</backgroundColor>
+    </gridtile>
+  </view>
+
+  <!-- GAMECAROUSEL VIEW — slightly bumped fonts for CRT readability -->
+  <view name="gamecarousel">
+    <gamecarousel name="gamecarousel">
+      <logoSize>0.185 0.185</logoSize>
+      <logoScale>4.0</logoScale>
+    </gamecarousel>
+    <text name="md_description">
+      <fontSize>0.030</fontSize>
+      <pos>0.55 0.66</pos>
+      <size>0.43 0.22</size>
+    </text>
+    <text name="md_developer">
+      <fontSize>0.032</fontSize>
+      <size>0.40 0.05</size>
+    </text>
+    <text name="md_lbl_players, md_lbl_releasedate">
+      <fontSize>0.030</fontSize>
+    </text>
+    <text name="md_players">
+      <fontSize>0.030</fontSize>
+    </text>
+    <datetime name="md_releasedate">
+      <fontSize>0.030</fontSize>
+    </datetime>
+    <text name="md_genre">
+      <pos>1 1</pos>
+    </text>
+    <!-- Hide thumbnail while scrolling; fade in only after selection stops -->
+    <image name="md_thumbnail">
+      <storyboard event="activate">
+        <animation property="opacity" begin="1400" from="0" to="1" duration="400" mode="EaseOut"/>
+        <animation property="scale" begin="1400" from="0" to="1" duration="400" mode="bump"/>
+      </storyboard>
+      <storyboard event="scroll">
+        <animation property="opacity" to="0" duration="80" mode="EaseOut"/>
+        <animation property="scale" to="0" duration="80" mode="EaseOut"/>
+      </storyboard>
+      <storyboard event="deactivate">
+        <animation property="opacity" to="0" duration="80" mode="EaseOut"/>
+        <animation property="scale" to="0" duration="80" mode="EaseOut"/>
+      </storyboard>
+    </image>
+  </view>
+
+  <!-- CUSTOM VIEWS — force 1x1 grid, large text -->
+  <customView name="Tiles,Icons">
+    <imagegrid name="gamegrid">
+      <autoLayout>1 1</autoLayout>
+      <pos>0.02 0.16</pos>
+      <size>0.96 0.77</size>
+      <padding>0 0</padding>
+      <margin>0 0</margin>
+      <scrollDirection>horizontal</scrollDirection>
+    </imagegrid>
+    <text name="gridtile">
+      <fontSize>0.050</fontSize>
+    </text>
+    <gridtile name="default">
+      <backgroundCornerSize>0 0</backgroundCornerSize>
+      <padding>0 0</padding>
+    </gridtile>
+    <gridtile name="selected">
+      <backgroundCornerSize>0 0</backgroundCornerSize>
+      <padding>0 0</padding>
+    </gridtile>
+    <image name="gridtile.image">
+      <roundCorners>0</roundCorners>
+    </image>
+  </customView>
+
+  <!-- Carousel custom view is tinyScreen="false" in stock Carbon, so it won't appear at 240p/480p -->
+
+  <customView name="Boxes">
+    <imagegrid name="gamegrid">
+      <autoLayout>2 1</autoLayout>
+      <pos>0.02 0.16</pos>
+      <size>0.96 0.77</size>
+      <scrollDirection>horizontal</scrollDirection>
+    </imagegrid>
+    <text name="gridtile">
+      <fontSize>0.050</fontSize>
+    </text>
+  </customView>
+</theme>


### PR DESCRIPTION
## Summary

- During CRT Script installation, the stock `es-theme-carbon` theme is automatically patched with a **CRT 240p Mode** subset toggle
- Copies `crt240p.xml` layout (font sizes, element positions, and overlay tweaks optimized for 320x240 on a 15kHz CRT) into the theme's `layouts/` folder
- Injects the `crt240p` subset block into `theme.xml` immediately after the `optimizesmallscreens` block — available at **all resolutions** (no `tinyScreen` gate)
- Auto-enables the toggle (`on`) when the user selects `320x240@60` as their EDID boot resolution; set to `off` for all other resolutions
- Stock `theme.xml` is backed up before patching so `restore_all()` fully recovers it; `crt240p.xml` is removed from the theme on restore

## Changes

| File | What |
|------|------|
| `Batocera-CRT-Script-v42.sh` | Copy `crt240p.xml`, inject subset block into `theme.xml`, write `es_settings.cfg` preference, add `theme.xml` to `FILES_TO_HANDLE` and `crt240p.xml` to `EXTRA_DELETE_FILES` |
| `Batocera-CRT-Script-v43.sh` | Same changes as v42 |
| `Geometry_modeline/crt240p.xml` **(new)** | CRT 240p layout — font sizes and element positions tuned for 320x240 on a 15kHz CRT TV |

## How To Test

1. Run a fresh CRT Script install selecting `320x240@60` as the EDID resolution
2. After install completes, go to **Main Menu > UI Settings > Theme Configuration**
3. Confirm **CRT 240p Mode** subset is present and set to `On`
4. Verify the EmulationStation UI is using the 240p-optimized layout (larger fonts, adjusted element positions)
5. Run a fresh install selecting any **non-320x240** resolution
6. Confirm **CRT 240p Mode** is present but set to `Off`
7. Run **Restore** from the CRT Script menu
8. Confirm `theme.xml` is back to stock and `layouts/crt240p.xml` is removed

## Test plan

- [ ] Fresh install at 320x240@60: `crt240p` subset present and auto-enabled in ES theme settings
- [ ] Fresh install at 640x480 or other resolution: `crt240p` subset present but set to off
- [ ] ES UI displays correctly with CRT 240p Mode on at 320x240
- [ ] ES UI unaffected with CRT 240p Mode off at other resolutions
- [ ] Restore: `theme.xml` reverted to stock, `crt240p.xml` removed from `layouts/`
- [ ] No regression on v42 installs
- [ ] No regression on v43 installs