### PR TITLE
Add blind CRT to HD combo for Steam Deck

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -5228,16 +5228,38 @@ chmod 644 "$CRT_ROMS/crt/overlays_overrides.sh.keys"
 chmod 755 /userdata/system/Batocera-CRT-Script/extra/overlays_overrides_script.sh
 
 #######################################################################################
-# Add Media Keys with restart for Xorg and restart Emulation Station
+# Media keys + blind CRT to HD chord (Steam Deck): combo, watcher, userdata mirror,
+# user service. combo.debug is never installed; remove it for full HD restore + shutdown.
 #######################################################################################
 cp /userdata/system/Batocera-CRT-Script/extra/media_keys/multimedia_keys.conf /userdata/system/configs/
 cp /userdata/system/Batocera-CRT-Script/extra/media_keys/esrestart /usr/bin
 cp /userdata/system/Batocera-CRT-Script/extra/media_keys/xrestart /usr/bin
 cp /userdata/system/Batocera-CRT-Script/extra/media_keys/emukill /usr/bin
+cp /userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-combo /tmp/crt-mode-switch-combo.install
+chmod 755 /tmp/crt-mode-switch-combo.install
+# Older bad deploys may have created /usr/bin/crt-mode-switch-combo as a directory; replace with file.
+rm -rf /usr/bin/crt-mode-switch-combo
+mv /tmp/crt-mode-switch-combo.install /usr/bin/crt-mode-switch-combo
+chmod 755 /usr/bin/crt-mode-switch-combo
+cp /userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-watcher.py /usr/bin
 chmod 644 /userdata/system/configs/multimedia_keys.conf
 chmod 755 /usr/bin/esrestart
 chmod 755 /usr/bin/xrestart
 chmod 755 /usr/bin/emukill
+chmod 755 /usr/bin/crt-mode-switch-combo
+chmod 755 /usr/bin/crt-mode-switch-watcher.py
+# Mirror into userdata (survives reboot without batocera-save-overlay; read-only /usr may reset).
+UD_MEDIA_KEYS="/userdata/system/Batocera-CRT-Script/extra/media_keys"
+mkdir -p "$UD_MEDIA_KEYS"
+cp -f /usr/bin/crt-mode-switch-combo "$UD_MEDIA_KEYS/crt-mode-switch-combo"
+cp -f /usr/bin/crt-mode-switch-watcher.py "$UD_MEDIA_KEYS/crt-mode-switch-watcher.py"
+chmod 755 "$UD_MEDIA_KEYS/crt-mode-switch-combo" "$UD_MEDIA_KEYS/crt-mode-switch-watcher.py"
+mkdir -p /userdata/system/services
+# Service prefers userdata watcher/combo paths (no overlay required to update them).
+cp /userdata/system/Batocera-CRT-Script/extra/media_keys/crt_mode_switch_watcher /userdata/system/services/crt_mode_switch_watcher
+chmod 755 /userdata/system/services/crt_mode_switch_watcher
+# Watcher is OFF by default; enable via HD/CRT Mode Switcher (Blind Switch Watcher) or:
+#   batocera-services enable crt_mode_switch_watcher && batocera-services start crt_mode_switch_watcher
 
 #######################################################################################
 # Add Kodi to ports folder

--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher_modules/02_hd_output_selection.sh
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher_modules/02_hd_output_selection.sh
@@ -368,68 +368,246 @@ show_boot_resolution_dialog() {
     done
 }
 
+#######################################################################################
+# Blind switch watcher (crt_mode_switch_watcher) - same HD backup gate as crt-mode-switch-combo.
+# Defined in this module with the other Mode Switch Configuration dialogs (EDIT_HD / EDIT_CRT / EDIT_BOOT).
+#######################################################################################
+_hd_backup_exists() {
+    local meta="/userdata/Batocera-CRT-Script-Backup/mode_backups/hd_mode/mode_metadata.txt"
+    [ -f "$meta" ] && grep -q '^MODE=hd' "$meta" 2>/dev/null
+}
+
+_watcher_enabled() {
+    local svcs
+    svcs="$(/usr/bin/batocera-settings-get system.services 2>/dev/null)"
+    echo " ${svcs} " | grep -q ' crt_mode_switch_watcher '
+}
+
+_modeswitcher_watcher_status_label() {
+    if ! _hd_backup_exists; then
+        echo "UNAVAILABLE"
+    elif _watcher_enabled; then
+        echo "ON"
+    else
+        echo "OFF"
+    fi
+}
+
+# Function: show_watcher_page
+# Purpose: Blind switch watcher config using the same select-then-confirm pattern as boot/output dialogs
+# Returns: 0
+show_watcher_page() {
+    local selected_action=""
+    local default_item=""
+
+    if ! _hd_backup_exists; then
+        dialog --title "Blind Switch Watcher" \
+               --backtitle "HD/CRT Mode Switcher" \
+               --msgbox "Enables a background service that watches for a button\ncombo and switches to HD Mode without needing a display.\nUseful when you power on away from a CRT.\n\nCombo: SELECT + START + L1 + L2 held 5 seconds.\n\nNOT AVAILABLE YET\nYou must complete one full HD/CRT round trip using the\nmode switcher first. This saves the HD settings that\nthe blind switch restores." \
+               16 62
+        return 0
+    fi
+
+    local current_state="OFF"
+    _watcher_enabled && current_state="ON"
+
+    while true; do
+        local menu_items=()
+        local on_marker="" off_marker=""
+
+        if [ "$current_state" = "ON" ]; then
+            on_marker="  [CURRENT]"
+        else
+            off_marker="  [CURRENT]"
+        fi
+
+        if [ "$selected_action" = "ENABLE" ]; then
+            on_marker="  [SELECTED]"
+        elif [ "$selected_action" = "DISABLE" ]; then
+            off_marker="  [SELECTED]"
+        fi
+
+        menu_items+=("ENABLE" "Watcher ON$on_marker")
+        menu_items+=("DISABLE" "Watcher OFF$off_marker")
+        menu_items+=("--------" "─────────────────────────────")
+        menu_items+=("CONFIRM" "Apply selected setting")
+        menu_items+=("CANCEL" "Go back")
+
+        if [ -z "$default_item" ]; then
+            if [ "$current_state" = "ON" ]; then
+                default_item="ENABLE"
+            else
+                default_item="DISABLE"
+            fi
+        fi
+
+        local choice
+        choice=$(dialog --title "Blind Switch Watcher Setup" \
+                       --backtitle "HD/CRT Mode Switcher" \
+                       --default-item "$default_item" \
+                       --no-cancel \
+                       --no-ok \
+                       --menu "Enables a background service that watches for a button\ncombo and switches to HD Mode without needing a display.\nUseful when you power on away from a CRT.\n\nCombo: SELECT + START + L1 + L2 held 5 seconds.\nRequires one full HD/CRT round trip first." \
+                       18 62 5 \
+                       "${menu_items[@]}" \
+                       3>&1 1>&2 2>&3)
+
+        local exit_code=$?
+
+        if [ $exit_code -ne 0 ]; then
+            return 0
+        fi
+
+        if [ "$choice" = "--------" ]; then
+            default_item="CONFIRM"
+            continue
+        fi
+
+        if [ "$choice" = "CANCEL" ]; then
+            return 0
+        fi
+
+        if [ "$choice" = "CONFIRM" ]; then
+            if [ -z "$selected_action" ]; then
+                dialog --title "No Change Selected" \
+                       --backtitle "HD/CRT Mode Switcher" \
+                       --msgbox "Select ENABLE or DISABLE first, then CONFIRM." \
+                       7 55
+                default_item="ENABLE"
+                continue
+            fi
+
+            if [ "$selected_action" = "ENABLE" ] && [ "$current_state" = "ON" ]; then
+                return 0
+            fi
+            if [ "$selected_action" = "DISABLE" ] && [ "$current_state" = "OFF" ]; then
+                return 0
+            fi
+
+            if [ "$selected_action" = "ENABLE" ]; then
+                if /usr/bin/batocera-services enable crt_mode_switch_watcher 2>/dev/null && \
+                   /usr/bin/batocera-services start crt_mode_switch_watcher 2>/dev/null; then
+                    dialog --title "Blind Switch Watcher" \
+                           --backtitle "HD/CRT Mode Switcher" \
+                           --msgbox "Watcher enabled and started.\n\nWill auto-start on every boot." \
+                           8 50
+                else
+                    dialog --title "Error" \
+                           --backtitle "HD/CRT Mode Switcher" \
+                           --msgbox "Could not enable watcher. Try from SSH:\n  batocera-services enable crt_mode_switch_watcher\n  batocera-services start crt_mode_switch_watcher" \
+                           10 62
+                fi
+            else
+                /usr/bin/batocera-services stop crt_mode_switch_watcher 2>/dev/null || true
+                if /usr/bin/batocera-services disable crt_mode_switch_watcher 2>/dev/null; then
+                    dialog --title "Blind Switch Watcher" \
+                           --backtitle "HD/CRT Mode Switcher" \
+                           --msgbox "Watcher disabled and stopped.\n\nWill not start on next boot." \
+                           8 50
+                else
+                    dialog --title "Error" \
+                           --backtitle "HD/CRT Mode Switcher" \
+                           --msgbox "Could not disable watcher. Try from SSH:\n  batocera-services stop crt_mode_switch_watcher\n  batocera-services disable crt_mode_switch_watcher" \
+                           10 62
+                fi
+            fi
+            return 0
+        fi
+
+        selected_action="$choice"
+        default_item="CONFIRM"
+    done
+}
+
 # Function: show_config_summary_dialog
 # Purpose: Show summary of all configs with EDIT option
 # Parameters: $1 - target_mode, $2 - hd_output, $3 - crt_output, $4 - crt_boot
-# Returns: Action in SUMMARY_ACTION variable ("confirm", "edit_hd", "edit_crt", "edit_boot", "cancel")
+# Returns: Action in SUMMARY_ACTION variable ("confirm", "edit_hd", "edit_crt", "edit_boot", "edit_watcher", "cancel")
 show_config_summary_dialog() {
     local target_mode="$1"
     local hd_output="$2"
     local crt_output="$3"
     local crt_boot="$4"
-    
-    local menu_items=()
-    
-    # Build summary display
-    local hd_display="HD Output:   $hd_output"
-    local crt_display="CRT Output:  $crt_output"
-    local boot_display="CRT Boot:    $crt_boot"
-    
-    # Add markers for current mode
-    if [ "$target_mode" = "hd" ]; then
-        hd_display="$hd_display  << SWITCHING TO"
-    else
-        crt_display="$crt_display  << SWITCHING TO"
-    fi
-    
-    menu_items+=("CONFIRM" ">>> Switch to $(get_mode_display_name "$target_mode")")
-    
-    # Add all EDIT options
-    menu_items+=("EDIT_HD" "Edit HD Output ($hd_output)")
-    menu_items+=("EDIT_CRT" "Edit CRT Output ($crt_output)")
-    menu_items+=("EDIT_BOOT" "Edit CRT Boot Resolution")
-    
-    menu_items+=("--------" "─────────────────────────────")
-    menu_items+=("CANCEL" "Return to EmulationStation")
-    
-    local choice
-    choice=$(dialog --title "Mode Switch Configuration" \
-                   --backtitle "HD/CRT Mode Switcher" \
-                   --default-item "CONFIRM" \
-                   --no-cancel \
-                   --no-ok \
-                   --menu "Current Configuration:\n\n$hd_display\n$crt_display\n$boot_display\n\nSelect action:" \
-                   20 70 6 \
-                   "${menu_items[@]}" \
-                   3>&1 1>&2 2>&3)
-    
-    local exit_code=$?
-    
-    if [ $exit_code -ne 0 ]; then
-        SUMMARY_ACTION="cancel"
-        return 1
-    fi
-    
-    case "$choice" in
-        "CONFIRM") SUMMARY_ACTION="confirm" ;;
-        "EDIT_HD") SUMMARY_ACTION="edit_hd" ;;
-        "EDIT_CRT") SUMMARY_ACTION="edit_crt" ;;
-        "EDIT_BOOT") SUMMARY_ACTION="edit_boot" ;;
-        "CANCEL"|"--------") SUMMARY_ACTION="cancel"; return 1 ;;
-        *) SUMMARY_ACTION="cancel"; return 1 ;;
-    esac
-    
-    return 0
+
+    while true; do
+        local menu_items=()
+
+        # Build summary display
+        local hd_display="HD Output:   $hd_output"
+        local crt_display="CRT Output:  $crt_output"
+        local boot_display="CRT Boot:    $crt_boot"
+        local watcher_display="Blind Switch Watcher:   $(_modeswitcher_watcher_status_label)"
+
+        # Add markers for current mode
+        if [ "$target_mode" = "hd" ]; then
+            hd_display="$hd_display  << SWITCHING TO"
+        else
+            crt_display="$crt_display  << SWITCHING TO"
+        fi
+
+        menu_items+=("CONFIRM" ">>> Switch to $(get_mode_display_name "$target_mode")")
+
+        # Add all EDIT options
+        menu_items+=("EDIT_HD" "Edit HD Output ($hd_output)")
+        menu_items+=("EDIT_CRT" "Edit CRT Output ($crt_output)")
+        menu_items+=("EDIT_BOOT" "Edit CRT Boot Resolution")
+        menu_items+=("EDIT_WATCHER" "Edit Blind Switch Watcher")
+
+        menu_items+=("--------" "─────────────────────────────")
+        menu_items+=("CANCEL" "Return to EmulationStation")
+
+        local choice exit_code
+        choice=$(dialog --title "Mode Switch Configuration" \
+                       --backtitle "HD/CRT Mode Switcher" \
+                       --default-item "CONFIRM" \
+                       --no-cancel \
+                       --no-ok \
+                       --menu "Current Configuration:\n\n$hd_display\n$crt_display\n$boot_display\n$watcher_display\n\nSelect action:" \
+                       22 70 7 \
+                       "${menu_items[@]}" \
+                       3>&1 1>&2 2>&3)
+        exit_code=$?
+        choice="${choice//$'\r'/}"
+        choice="${choice//$'\n'/}"
+        choice="${choice#"${choice%%[![:space:]]*}"}"
+        choice="${choice%"${choice##*[![:space:]]}"}"
+
+        if [ $exit_code -ne 0 ]; then
+            declare -g SUMMARY_ACTION="cancel"
+            return 1
+        fi
+
+        case "$choice" in
+            "CONFIRM")
+                declare -g SUMMARY_ACTION="confirm"
+                return 0
+                ;;
+            "EDIT_HD")
+                declare -g SUMMARY_ACTION="edit_hd"
+                return 0
+                ;;
+            "EDIT_CRT")
+                declare -g SUMMARY_ACTION="edit_crt"
+                return 0
+                ;;
+            "EDIT_BOOT")
+                declare -g SUMMARY_ACTION="edit_boot"
+                return 0
+                ;;
+            "EDIT_WATCHER")
+                declare -g SUMMARY_ACTION="edit_watcher"
+                return 0
+                ;;
+            "CANCEL"|"--------")
+                declare -g SUMMARY_ACTION="cancel"
+                return 1
+                ;;
+            *)
+                declare -g SUMMARY_ACTION="cancel"
+                return 1
+                ;;
+        esac
+    done
 }
 
 # Function: get_current_crt_backup_output
@@ -698,6 +876,10 @@ run_mode_switch_ui() {
                     if [ $? -eq 0 ]; then
                         working_boot="$SELECTED_BOOT"
                     fi
+                    continue
+                    ;;
+                "edit_watcher")
+                    show_watcher_page
                     continue
                     ;;
                 "cancel"|*)

--- a/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-combo
+++ b/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-combo
@@ -1,0 +1,372 @@
+#!/bin/bash
+#
+# Blind CRT -> HD mode switch (handheld chord: SELECT+START+L1+L2 on Steam Deck).
+#
+# Started by Batocera user service crt_mode_switch_watcher (evdev-only) or by
+# triggerhappy on boards where multimedia_keys.conf defines the BTN_* chord.
+# Single-instance flock is taken before the blind sleep so rapid chord spawns
+# cannot clobber each other. We still sleep 5 seconds after acquiring the lock.
+#
+# HD backup guard: requires a completed HD mode backup from the UI switcher
+# (mode_metadata.txt with MODE=hd). This avoids restoring into a sparse/factory
+# HD state when the user has never successfully saved HD mode.
+#
+# Haptic: best-effort rumble via python3 + evdev after the 5s blind wait (same
+# stack as Batocera configgen). Tries evdev nodes named "Steam Deck" first, then
+# other event* devices with FF_RUMBLE; hidraw fallback matches Deck gamepad HID uevent
+# names (e.g. Valve Software Steam Deck Controller). See ordered_paths() / uevent_is_deck_gamepad().
+#
+# DEBUG dry-run: optional empty file /userdata/system/crt-mode-switch-combo.debug
+# skips guards, backup/restore, and shutdown (use only while testing). Remove it
+# for production; the installer does not create this file.
+#
+# After HD files are restored on disk: dual-boot calls /sbin/poweroff, else /sbin/reboot.
+# Handheld QA checklist (run on device):
+# - Cold boot: chord fires combo (Deck: crt_mode_switch_watcher; others: thd if configured).
+# - After switch: machine powers off (dual-boot) or reboots (single-boot) into HD.
+# - DEBUG: touch /userdata/system/crt-mode-switch-combo.debug to skip HD restore entirely.
+# - All status lines go to /userdata/system/logs/crt-script-mode-switch.log (persists
+#   without batocera-save-overlay), BUILD_15KHz_Batocera.log, and the same legacy
+#   path as the watcher (crt-mode-switch-watcher.log) so one tail shows combo+haptic.
+# - Rumble felt on supported pads; switch works without rumble.
+
+set +e
+
+SCRIPT_DIR="/userdata/system/Batocera-CRT-Script"
+MODE_BACKUP_DIR="/userdata/Batocera-CRT-Script-Backup/mode_backups"
+CRT_BACKUP_DIR="/userdata/Batocera-CRT-Script-Backup/BACKUP"
+CRT_BACKUP_CHECK="${CRT_BACKUP_DIR%/*}/backup.file"
+
+if [ -d "/userdata/.roms_base" ]; then
+  CRT_ROMS="/userdata/.roms_base"
+else
+  CRT_ROMS="/userdata/roms"
+fi
+# CRT_ROMS used by sourced 03_backup_restore.sh (same as mode_switcher.sh).
+
+LOG_FILE="/userdata/system/logs/BUILD_15KHz_Batocera.log"
+CRT_SCRIPT_LOG="/userdata/system/logs/crt-script-mode-switch.log"
+CRT_WATCHER_LEGACY_LOG="/userdata/system/logs/crt-mode-switch-watcher.log"
+
+_crt_script_log() {
+  local body="crt-mode-switch-combo: $*"
+  local ts="[$(date +"%Y-%m-%d %H:%M:%S")] ${body}"
+  mkdir -p /userdata/system/logs 2>/dev/null || true
+  echo "$ts" >>"$CRT_SCRIPT_LOG" 2>/dev/null || true
+  echo "[$(date +"%H:%M:%S")]: ${body}" >>"$LOG_FILE" 2>/dev/null || true
+  echo "$ts" >>"$CRT_WATCHER_LEGACY_LOG" 2>/dev/null || true
+}
+
+MODULES_DIR="${SCRIPT_DIR}/Geometry_modeline/mode_switcher_modules"
+
+if [ ! -d "$MODULES_DIR" ]; then
+  _crt_script_log "skipped (missing MODULES_DIR ${MODULES_DIR})"
+  exit 0
+fi
+
+# shellcheck source=/dev/null
+source "${MODULES_DIR}/01_mode_detection.sh"
+# shellcheck source=/dev/null
+source "${MODULES_DIR}/03_backup_restore.sh"
+
+_combo_hd_backup_ok() {
+  local meta="${MODE_BACKUP_DIR}/hd_mode/mode_metadata.txt"
+  [ -f "$meta" ] || return 1
+  grep -q '^MODE=hd' "$meta" 2>/dev/null || return 1
+  return 0
+}
+
+_combo_haptic_ack() {
+  export CRT_COMBO_LOG_PATH="$CRT_SCRIPT_LOG"
+  export CRT_COMBO_LOG_LEGACY="$CRT_WATCHER_LEGACY_LOG"
+  _crt_script_log "haptic: invoking python (evdev FF_RUMBLE, hidraw fallback for Deck HID)"
+  python3 - <<'PY'
+import glob
+import os
+import struct
+import time
+
+try:
+    from evdev import InputDevice, ecodes
+    from evdev.ff import Effect
+except ImportError as _e:
+    _paths = (
+        os.environ.get("CRT_COMBO_LOG_PATH", ""),
+        os.environ.get("CRT_COMBO_LOG_LEGACY", ""),
+    )
+    _line = (
+        f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] "
+        f"crt-mode-switch-combo: haptic python ImportError (no evdev): {_e!r}\n"
+    )
+    for _p in _paths:
+        if not _p:
+            continue
+        try:
+            os.makedirs(os.path.dirname(_p), exist_ok=True)
+            with open(_p, "a", encoding="utf-8", errors="replace") as _f:
+                _f.write(_line)
+        except OSError:
+            pass
+    raise SystemExit(2)
+
+
+def log_line(msg: str) -> None:
+    line = (
+        f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] "
+        f"crt-mode-switch-combo: haptic {msg}\n"
+    )
+    for p in (
+        os.environ.get("CRT_COMBO_LOG_PATH", ""),
+        os.environ.get("CRT_COMBO_LOG_LEGACY", ""),
+    ):
+        if not p:
+            continue
+        try:
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "a", encoding="utf-8", errors="replace") as f:
+                f.write(line)
+        except OSError:
+            pass
+
+
+def uevent_is_deck_gamepad(txt: str) -> bool:
+    """Kernel uevent HID_NAME is 'Steam Deck' or 'Valve Software Steam Deck Controller'. Skip Motion."""
+    hid = ""
+    for line in txt.splitlines():
+        if line.startswith("HID_NAME="):
+            hid = line.split("=", 1)[1].strip()
+            break
+    if not hid or "Motion" in hid:
+        return False
+    if hid == "Steam Deck":
+        return True
+    return "Steam Deck" in hid
+
+
+def find_steam_deck_hidraws() -> list[str]:
+    """hidraw nodes whose uevent HID_NAME is Deck gamepad (Steam Deck or Valve …). hid-steam 0xEB."""
+    out: list[str] = []
+    for uevent in sorted(glob.glob("/sys/class/hidraw/hidraw*/device/uevent")):
+        try:
+            txt = open(uevent, encoding="utf-8", errors="replace").read()
+        except OSError:
+            continue
+        if not uevent_is_deck_gamepad(txt):
+            continue
+        parts = uevent.split("/")
+        if len(parts) >= 5 and parts[4].startswith("hidraw"):
+            out.append("/dev/" + parts[4])
+    return out
+
+
+def try_hidraw_rumble(hpath: str) -> bool:
+    """Match drivers/hid/hid-steam.c ID_TRIGGER_RUMBLE_CMD (0xEB), length byte 9."""
+    left = 0xFFFF
+    right = 0xFFFF
+    intensity = 0
+    left_gain = 2
+    right_gain = 0
+    rep = bytearray(11)
+    rep[0] = 0xEB
+    rep[1] = 9
+    rep[2] = 0
+    struct.pack_into("<H", rep, 3, intensity)
+    struct.pack_into("<H", rep, 5, left)
+    struct.pack_into("<H", rep, 7, right)
+    rep[9] = left_gain & 0xFF
+    rep[10] = right_gain & 0xFF
+    stop = bytearray(11)
+    stop[0] = 0xEB
+    stop[1] = 9
+    # Some kernels expect O_RDWR on hidraw.
+    for rep_bytes in (bytes(rep), b"\x00" + bytes(rep)):
+        try:
+            fd = os.open(hpath, os.O_RDWR)
+            try:
+                os.write(fd, rep_bytes)
+            finally:
+                os.close(fd)
+            log_line(f"hidraw wrote RUMBLE_CMD len={len(rep_bytes)} to {hpath}")
+            time.sleep(0.45)
+            fd2 = os.open(hpath, os.O_RDWR)
+            try:
+                os.write(fd2, bytes(stop) if len(rep_bytes) == len(rep) else b"\x00" + bytes(stop))
+            finally:
+                os.close(fd2)
+            log_line(f"hidraw sent rumble stop to {hpath}")
+            return True
+        except OSError as e:
+            log_line(f"hidraw {hpath} try len={len(rep_bytes)} failed: {e!r}")
+    return False
+
+
+def ordered_paths():
+    paths = sorted(glob.glob("/dev/input/event*"))
+    deck, rest = [], []
+    for path in paths:
+        try:
+            d = InputDevice(path)
+            n = (d.name or "").strip()
+            d.close()
+        except OSError:
+            continue
+        if n == "Steam Deck":
+            deck.append(path)
+        else:
+            rest.append(path)
+    return deck + rest
+
+
+def try_evdev_ff(path: str) -> bool:
+    try:
+        dev = InputDevice(path)
+    except OSError as e:
+        log_line(f"open {path} failed: {e!r}")
+        return False
+    name = (dev.name or "").strip()
+    caps = dev.capabilities()
+    ff_codes = caps.get(ecodes.EV_FF) or []
+    if ecodes.FF_RUMBLE not in ff_codes:
+        log_line(f"{path} ({name!r}) no FF_RUMBLE; EV_FF={ff_codes!r}")
+        try:
+            dev.close()
+        except OSError:
+            pass
+        return False
+    effect = Effect()
+    effect.type = ecodes.FF_RUMBLE
+    effect.id = -1
+    effect.direction = 0
+    effect.ff_trigger.button = 0
+    effect.ff_trigger.interval = 0
+    effect.ff_replay.length = 900
+    effect.ff_replay.delay = 0
+    _rum = getattr(effect.u, "rumble", None) or getattr(
+        effect.u, "ff_rumble_effect", None
+    )
+    if _rum is None:
+        log_line(f"{path} ({name!r}) evdev Effect.u has no rumble/ff_rumble_effect")
+        return False
+    _rum.strong_magnitude = 0xFFFF
+    _rum.weak_magnitude = 0xFFFF
+    try:
+        eid = dev.upload_effect(effect)
+        dev.write(ecodes.EV_FF, eid, 1)
+        try:
+            dev.syn()
+        except AttributeError:
+            pass
+        time.sleep(0.95)
+        dev.write(ecodes.EV_FF, eid, 0)
+        try:
+            dev.syn()
+        except AttributeError:
+            pass
+        dev.erase_effect(eid)
+        log_line(f"evdev FF_RUMBLE ok {path} ({name!r})")
+        return True
+    except (OSError, AttributeError, ValueError, TypeError) as e:
+        log_line(f"{path} ({name!r}) evdev play failed: {e!r}")
+        return False
+    finally:
+        try:
+            dev.close()
+        except Exception:
+            pass
+
+
+def main() -> None:
+    log_line("python haptic start (scan evdev then hidraw)")
+    for path in ordered_paths():
+        if try_evdev_ff(path):
+            return
+    for hp in find_steam_deck_hidraws():
+        if try_hidraw_rumble(hp):
+            return
+    log_line("no evdev FF_RUMBLE and no hidraw gamepad rumble (CONFIG_STEAM_FF / hid-steam)")
+
+
+if __name__ == "__main__":
+    main()
+PY
+  _haptic_py=$?
+  _crt_script_log "haptic: python finished (exit ${_haptic_py})"
+}
+
+# Single-instance lock BEFORE blind wait. Parallel spawns (rapid chord) used to
+# each sleep 5s then truncate this file with exec 9>, breaking flock and exiting silent.
+exec 9>/tmp/crt-mode-switch-combo.lock
+if ! flock -n 9; then
+  _crt_script_log "skipped (lock busy or another instance running)"
+  exit 0
+fi
+
+_crt_script_log "lock acquired; 5s blind wait then haptic"
+
+# Hold / blind-wait (see header).
+sleep 5
+
+_combo_haptic_ack
+
+# DEBUG: skip mode switch and reboot while tuning haptics (stay in CRT).
+if [ -f /userdata/system/crt-mode-switch-combo.debug ]; then
+  _crt_script_log "DEBUG dry-run: skipping guards backup/restore reboot (remove /userdata/system/crt-mode-switch-combo.debug for normal switch)"
+  exit 0
+fi
+
+if ! check_crt_script_installed; then
+  _crt_script_log "skipped (CRT install marker missing: ${CRT_BACKUP_CHECK})"
+  exit 0
+fi
+
+_current_mode="$(detect_current_mode 2>/dev/null | head -1 | tr -d '\r\n[:space:]')"
+if [ "$_current_mode" != "crt" ]; then
+  _crt_script_log "skipped (not CRT mode; detect_current_mode='${_current_mode}')"
+  exit 0
+fi
+
+if ! _combo_hd_backup_ok; then
+  _crt_script_log "no usable HD mode backup (need hd_mode/mode_metadata.txt MODE=hd)"
+  exit 0
+fi
+
+mkdir -p "$MODE_BACKUP_DIR" 2>/dev/null || true
+
+if ! backup_mode_files "crt"; then
+  _crt_script_log "backup_mode_files crt failed"
+  exit 0
+fi
+
+if ! restore_mode_files "hd"; then
+  _crt_script_log "restore_mode_files hd failed"
+  exit 0
+fi
+
+_crt_script_log "FINAL PRE-REBOOT VERIFICATION..."
+if [ -f "/userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt.cfg" ]; then
+  mkdir -p /userdata/system/configs/emulationstation 2>/dev/null || true
+  cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/es_systems_crt.cfg /userdata/system/configs/emulationstation/es_systems_crt.cfg 2>/dev/null || true
+  chmod 644 /userdata/system/configs/emulationstation/es_systems_crt.cfg 2>/dev/null || true
+  touch /userdata/system/configs/emulationstation/es_systems_crt.cfg 2>/dev/null || true
+  sync 2>/dev/null || true
+  sync 2>/dev/null || true
+  if grep -qE "emulatorlauncher|crt-launcher" /userdata/system/configs/emulationstation/es_systems_crt.cfg 2>/dev/null; then
+    _crt_script_log "FINAL VERIFICATION PASSED: es_systems_crt.cfg"
+  else
+    _crt_script_log "FINAL VERIFICATION FAILED: es_systems_crt.cfg"
+  fi
+fi
+
+sleep 2
+
+# Use absolute paths: user services / Popen often have PATH without /sbin, so bare
+# "poweroff" can be missing and exit silently before the kernel acts.
+if is_dualboot_system; then
+  _crt_script_log "shutdown: dual-boot (/boot/crt/linux + initrd-crt.gz) -> /sbin/poweroff"
+  sync 2>/dev/null || true
+  /sbin/poweroff 2>/dev/null || /sbin/shutdown -P -h now 2>/dev/null || _crt_script_log "ERROR: poweroff failed (check root / PATH)"
+else
+  _crt_script_log "shutdown: single-boot -> /sbin/reboot"
+  sync 2>/dev/null || true
+  /sbin/reboot 2>/dev/null || /sbin/shutdown -r now 2>/dev/null || _crt_script_log "ERROR: reboot failed (check root / PATH)"
+fi

--- a/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-watcher.py
+++ b/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-watcher.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Watch the Steam Deck gamepad evdev node for a 4-button chord, then run
+crt-mode-switch-combo via bash (same intent as triggerhappy BTN_* rules).
+
+Chord: SELECT + START + L1 + L2 (BTN_SELECT, BTN_START, BTN_TL, BTN_TL2).
+If any code is missing from the device caps, verify with: evtest /dev/input/eventN
+
+Batocera's triggerhappy watches /dev/input/event*; multi-button rules can fail
+on Deck due to global key state. This watcher binds one gamepad node only.
+
+Node selection: prefers the device named exactly 'Steam Deck', then other
+Deck gamepad names (e.g. 'Valve Software Steam Deck Controller'), excluding
+Motion Sensors, Steam Mouse, and Virtual devices. Only nodes that expose all
+chord keys are considered.
+
+Set CRT_MODE_SWITCH_WATCHER_DEBUG=1 for per-key log lines (or create empty file
+/userdata/system/crt-mode-switch-watcher.debug and restart the service; the
+service wrapper enables DEBUG when that file exists).
+
+Writes the same lines to BOTH:
+  - /userdata/system/logs/crt-script-mode-switch.log (CRT Script unified log)
+  - /userdata/system/logs/crt-mode-switch-watcher.log (legacy path; tail either)
+
+Truncating only one file leaves old lines in the other. To clear both:
+  truncate -s0 /userdata/system/logs/crt-script-mode-switch.log
+  truncate -s0 /userdata/system/logs/crt-mode-switch-watcher.log
+"""
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import time
+
+try:
+    from evdev import InputDevice, ecodes
+except ImportError:
+    sys.exit(0)
+
+CRT_SCRIPT_LOG = "/userdata/system/logs/crt-script-mode-switch.log"
+LEGACY_WATCHER_LOG = "/userdata/system/logs/crt-mode-switch-watcher.log"
+_WATCHER_REV = "prod-20260501-deck-paths"
+_COMBO_UD = "/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-combo"
+_COMBO_SYS = "/usr/bin/crt-mode-switch-combo"
+SELECT = ecodes.BTN_SELECT
+START = ecodes.BTN_START
+# L1 / L2 (SDL2 jstest on Deck: 7 = L1, 9 = L2)
+L1 = ecodes.BTN_TL
+L2 = ecodes.BTN_TL2
+CHORD_KEYS = (SELECT, START, L1, L2)
+_DEBUG = os.environ.get("CRT_MODE_SWITCH_WATCHER_DEBUG") == "1"
+
+
+def _log(msg: str) -> None:
+    line = f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] crt-mode-switch-watcher: {msg}\n"
+    for path in (CRT_SCRIPT_LOG, LEGACY_WATCHER_LOG):
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "a", encoding="utf-8", errors="replace") as f:
+                f.write(line)
+        except OSError:
+            pass
+
+
+def _deck_name_rank(name: str) -> int | None:
+    """Lower rank = higher preference. None = not a Deck gamepad candidate."""
+    n = (name or "").strip()
+    if n == "Steam Deck":
+        return 0
+    if any(x in n for x in ("Motion", "Mouse", "Virtual")):
+        return None
+    if "Valve" in n and "Deck" in n:
+        return 1
+    if "Deck" in n:
+        return 2
+    return None
+
+
+def find_steam_deck() -> InputDevice | None:
+    """Open the best evdev node that exposes all CHORD_KEYS."""
+    ranked: list[tuple[int, str]] = []
+    for path in sorted(glob.glob("/dev/input/event*")):
+        try:
+            d = InputDevice(path)
+        except OSError:
+            continue
+        rk = _deck_name_rank(d.name or "")
+        if rk is None:
+            try:
+                d.close()
+            except OSError:
+                pass
+            continue
+        try:
+            caps = set(d.capabilities().get(ecodes.EV_KEY, []))
+        except (OSError, AttributeError):
+            try:
+                d.close()
+            except OSError:
+                pass
+            continue
+        if any(c not in caps for c in CHORD_KEYS):
+            try:
+                d.close()
+            except OSError:
+                pass
+            continue
+        try:
+            d.close()
+        except OSError:
+            pass
+        ranked.append((rk, path))
+    if not ranked:
+        return None
+    ranked.sort(key=lambda x: (x[0], x[1]))
+    try:
+        return InputDevice(ranked[0][1])
+    except OSError:
+        return None
+
+
+def _combo_path() -> str:
+    if os.path.isfile(_COMBO_UD):
+        return _COMBO_UD
+    return _COMBO_SYS
+
+
+def _spawn_combo() -> None:
+    combo = _combo_path()
+    if not os.path.isfile(combo):
+        _log(f"combo script missing (checked {_COMBO_UD} and {_COMBO_SYS})")
+        return
+    try:
+        subprocess.Popen(
+            ["/bin/bash", combo],
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as e:
+        _log(f"spawn failed: {e}")
+
+
+def _chord_labels() -> str:
+    return "SELECT+START+L1+L2 (BTN_SELECT+BTN_START+BTN_TL+BTN_TL2)"
+
+
+def watch_device(dev: InputDevice) -> None:
+    caps = set(dev.capabilities().get(ecodes.EV_KEY, []))
+    missing = [c for c in CHORD_KEYS if c not in caps]
+    if missing:
+        _log(f"{dev.path} lacks required EV_KEY codes {missing}; closing")
+        return
+
+    _log(
+        f"listening {dev.path} ({dev.name!r}) rev={_WATCHER_REV} chord={_chord_labels()}"
+    )
+    armed = True
+    down = {c: False for c in CHORD_KEYS}
+
+    for ev in dev.read_loop():
+        if ev.type != ecodes.EV_KEY:
+            continue
+        if ev.code not in CHORD_KEYS:
+            continue
+        down[ev.code] = ev.value in (1, 2)
+        if _DEBUG:
+            if ev.value == 1:
+                _log(f"keydown code={ev.code}")
+            elif ev.value == 0:
+                _log(f"keyup code={ev.code}")
+
+        if all(down[c] for c in CHORD_KEYS) and armed:
+            armed = False
+            _log(f"chord matched ({_chord_labels()}): spawning bash {_combo_path()}")
+            _spawn_combo()
+
+        if not any(down[c] for c in CHORD_KEYS):
+            armed = True
+
+
+def main() -> None:
+    _log(
+        f"watcher main start rev={_WATCHER_REV} pid={os.getpid()} "
+        f"DEBUG={_DEBUG} chord_keys={CHORD_KEYS}"
+    )
+    while True:
+        dev = find_steam_deck()
+        if dev is None:
+            _log("Deck gamepad evdev not found; sleep 30s and retry")
+            time.sleep(30)
+            continue
+        try:
+            watch_device(dev)
+        except OSError as e:
+            _log(f"read_loop ended: {e}")
+        except Exception as e:
+            _log(f"unexpected error: {e!r}")
+        finally:
+            try:
+                dev.close()
+            except OSError:
+                pass
+        _log("device closed; sleep 2s and reopen")
+        time.sleep(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/userdata/system/Batocera-CRT-Script/extra/media_keys/crt_mode_switch_watcher
+++ b/userdata/system/Batocera-CRT-Script/extra/media_keys/crt_mode_switch_watcher
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Batocera user service: blind CRT to HD chord (SELECT+START+L1+L2) -> crt-mode-switch-combo (Steam Deck).
+# Installed to /userdata/system/services/crt_mode_switch_watcher and enabled via system.services.
+
+PIDFILE=/var/run/crt-mode-switch-watcher.pid
+
+case "$1" in
+start)
+	if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+		exit 0
+	fi
+	WPY_UD="/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-watcher.py"
+	WPY_SYS="/usr/bin/crt-mode-switch-watcher.py"
+	if [ -f "$WPY_UD" ]; then
+		# Touch /userdata/system/crt-mode-switch-watcher.debug to log every chord-key press/release.
+		[ -f /userdata/system/crt-mode-switch-watcher.debug ] && export CRT_MODE_SWITCH_WATCHER_DEBUG=1
+		/usr/bin/python3 "$WPY_UD" &
+	elif [ -f "$WPY_SYS" ]; then
+		[ -f /userdata/system/crt-mode-switch-watcher.debug ] && export CRT_MODE_SWITCH_WATCHER_DEBUG=1
+		/usr/bin/python3 "$WPY_SYS" &
+	else
+		exit 0
+	fi
+	echo $! >"$PIDFILE"
+	;;
+stop)
+	if [ -f "$PIDFILE" ]; then
+		kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null || true
+		rm -f "$PIDFILE"
+	fi
+	pkill -f 'crt-mode-switch-watcher.py' 2>/dev/null || true
+	;;
+status)
+	if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+		echo "crt_mode_switch_watcher: running pid=$(cat "$PIDFILE")"
+	else
+		echo "crt_mode_switch_watcher: stopped"
+	fi
+	;;
+*)
+	;;
+esac
+exit 0

--- a/userdata/system/Batocera-CRT-Script/extra/media_keys/multimedia_keys.conf
+++ b/userdata/system/Batocera-CRT-Script/extra/media_keys/multimedia_keys.conf
@@ -8,6 +8,9 @@ KEY_POWER       0               batocera-shutdown 0
 KEY_F3+KEY_RIGHTALT          1               bash /usr/bin/emukill
 KEY_F2+KEY_RIGHTALT          1               bash /usr/bin/xrestart
 KEY_F1+KEY_RIGHTALT          1               bash /usr/bin/esrestart
+# CRT blind HD switch: SELECT+START+L1+L2 on Steam Deck via user service
+# crt_mode_switch_watcher (evdev). triggerhappy multi-BTN rules are unreliable on Deck;
+# do not add BTN_* lines here for this chord.
 KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop
 KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 chvt 1
 KEY_LEFTMETA    1               batocera-brightness cycle


### PR DESCRIPTION
## Summary

See [CRT Combo Mode Switch (Controller Combo to Switch CRT → HD)](https://github.com/net-terminal-gene/Batocera-Development-KB/blob/main/entries/2026-04-29_crt-combo-mode-switch/plan.md) for more details.

Blind **CRT to HD** path when the built-in display cannot show 15kHz (e.g. Steam Deck away from a CRT). User holds **SELECT+START+L1+L2**; after a **5s** blind window the pad rumbles, then the system restores the saved HD mode from backup and **powers off** (dual-boot) or **reboots** (single-boot).

**Watcher will only be on when toggled to Enabled using the HD/CRT Mode Switcher app and is in CRT Mode.**

## What is included

- **`crt_mode_switch_watcher`** (Batocera user service) + **`crt-mode-switch-watcher.py`**: watches one ranked Deck gamepad evdev node, spawns **`/bin/bash`** on **`crt-mode-switch-combo`** (userdata path preferred).
- **`crt-mode-switch-combo`**: **`flock`**, **`sleep 5`**, embedded Python haptics (**`FF_RUMBLE`**, **`ff_rumble_effect`**, hidraw fallback), optional **`/userdata/system/crt-mode-switch-combo.debug`** for haptic-only QA, then **`01_mode_detection` / `03_backup_restore`**, **`es_systems_crt.cfg`** mirror, **`/sbin/poweroff`** or **`/sbin/reboot`**.
- **`Batocera-CRT-Script-v43.sh`**: deploy combo, watcher, service file. Watcher is **OFF by default**; user enables via Mode Switcher UI or SSH.
- **`multimedia_keys.conf`**: documents that the Deck chord is **not** implemented as **`BTN_*`** triggerhappy lines (unreliable on Deck for this chord).
- **Blind Switch Watcher UI toggle** in Mode Switch Configuration (EDIT_WATCHER):
  - Same select-then-confirm pattern as EDIT_HD / EDIT_CRT / EDIT_BOOT
  - Gated on HD backup existence (must complete one full HD/CRT round trip first)
  - Shows "NOT AVAILABLE YET" info page when prerequisites not met
    - <img width="1201" height="736" alt="blind-not-ready" src="https://github.com/user-attachments/assets/17486eab-3aab-4b9d-bd3d-c414a86f7dfb" />
  - ENABLE/DISABLE with `[CURRENT]` / `[SELECTED]` markers
    - <img width="1202" height="792" alt="blind-edit" src="https://github.com/user-attachments/assets/0732e0d2-7b43-4a98-8ecf-31cd08f30c92" />
  - Watcher status shown on summary page (`ON` / `OFF` / `UNAVAILABLE`)
    - <img width="1216" height="967" alt="blind-config" src="https://github.com/user-attachments/assets/1e5b437e-92b3-4c09-afa3-6fb5277641f2" />

## Testing

Validated on a **fresh v43 flash** with full ALLINONE install: chord, haptics, HD restore, shutdown/reboot, round-trip with UI mode switcher and HD backup. Watcher toggle tested: enable/disable persists across mode switches, combo only fires in CRT mode.

## Notes

- First HD save must exist from the UI switcher (**`mode_metadata.txt`** **`MODE=hd`**) before blind restore.
- Remove **`crt-mode-switch-combo.debug`** for production behavior (installer does not create it).
- Full reboot required after enabling watcher for it to be active (service starts on boot).