### PR TITLE
Phase 1 X11 install: official v43 URLs, local MD5 validation, SysRq shutdown fix

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -686,10 +686,12 @@ backup_restore_main() {
 #####################    WAYLAND / X11 PHASE 1 FUNCTIONS START     ####################
 ########################################################################################
 
+X11_IMAGE_URL="https://sour-silent-prune.6fcff5d8.katapult.cloud/images/batocera-x86_64-43-20260430.img.gz"
+X11_MD5_URL="https://mirrors.o2switch.fr/batocera/x86_64/stable/last/batocera-x86_64-43-20260430.img.gz.md5"
+
 sanitize_image_url() {
   IMAGE_URL="${IMAGE_URL%.md5}"
   IMAGE_URL="${IMAGE_URL% }"
-  MD5_URL="${IMAGE_URL}.md5"
 }
 
 scan_for_x11_image() {
@@ -762,6 +764,16 @@ download_x11_image() {
     if wget --progress=bar:force -O "$part_file" "$IMAGE_URL" 2>&1; then
       mv "$part_file" "$IMAGE_PATH"
       ok_box "Download complete: ${filename}"
+      # Also download the .md5 file from the official mirror
+      local md5_url="${X11_MD5_URL}"
+      local md5_dest="${IMAGE_PATH}.md5"
+      if wget -q -O "$md5_dest" "$md5_url" 2>/dev/null; then
+        ok_box "MD5 checksum downloaded: ${filename}.md5"
+      else
+        err_box "Warning: could not download .md5 checksum file"
+        box_center "URL: $md5_url"
+        box_center "MD5 validation will fail without this file."
+      fi
       return 0
     else
       rm -f "$part_file"
@@ -798,20 +810,34 @@ download_x11_image() {
 }
 
 validate_md5() {
+  local md5_file="${IMAGE_PATH}.md5"
+
   box_hash
   box_center "MD5 Validation"
   box_hash
   box_empty
+
+  if [ ! -f "$md5_file" ]; then
+    err_box "MD5 checksum file not found"
+    box_center "Expected: ${md5_file}"
+    box_center "Transfer the .md5 file alongside the image."
+    box_empty
+    box_hash
+    echo ""
+    return 1
+  fi
+
   box_center "Checking file against official Batocera checksum..."
   box_empty
 
   local official_md5
-  official_md5=$(wget -q -O - "$MD5_URL" 2>/dev/null | awk '{print $1}' | tr -d ' \n\r')
+  official_md5=$(awk '{print $1}' "$md5_file" | tr -d ' \n\r')
 
   if [ -z "$official_md5" ]; then
-    err_box "Could not fetch MD5 checksum from mirror"
-    box_center "URL: $MD5_URL"
-    box_center "Check your internet connection or the URL."
+    err_box "MD5 file is empty or unreadable"
+    box_center "File: ${md5_file}"
+    box_empty
+    box_hash
     echo ""
     return 1
   fi
@@ -848,41 +874,43 @@ prompt_image_source() {
       if [ "$count" -eq 1 ]; then
         local fsize
         fsize=$(du -h "$IMAGE_CANDIDATES" 2>/dev/null | cut -f1)
+        local md5_file="${IMAGE_CANDIDATES}.md5"
         box_hash
         box_center "X11 Batocera Image Found"
         box_hash
         box_empty
-        box_center "${IMAGE_CANDIDATES}  (${fsize})"
-        box_empty
-        box_center "MD5 will be verified against the official Batocera"
-        box_center "checksum before use."
-        box_empty
-        box_hash
-        echo ""
-        echo "  (1) Use this file"
-        echo "  (2) Enter download URL instead"
-        echo "  (3) Cancel"
+        box_center "Image: ${IMAGE_CANDIDATES}  (${fsize})"
+        if [ -f "$md5_file" ]; then
+          box_center "MD5:   ${md5_file}"
+          box_empty
+          box_center "MD5 will be verified against the official Batocera"
+          box_center "checksum before use."
+          box_empty
+          box_hash
+          echo ""
+          echo "  (1) Use this file"
+          echo "  (2) Download from official server instead"
+          echo "  (3) Cancel"
+        else
+          box_empty
+          box_center "${RED}MD5 checksum file not found.${NOCOLOR}"
+          box_center "You must also transfer the .md5 file from the"
+          box_center "Batocera download page to the same location."
+          box_empty
+          box_hash
+          echo ""
+          echo "  (1) Scan again — I have added the .md5 file"
+          echo "  (2) Download from official server instead"
+          echo "  (3) Cancel"
+        fi
         echo ""
         read -r img_choice
         case "$img_choice" in
           1)
+            if [ ! -f "$md5_file" ]; then
+              continue
+            fi
             IMAGE_PATH="$IMAGE_CANDIDATES"
-            # OFFICIAL: hardcoded URL — uncomment when v43 ships publicly
-            # IMAGE_URL="https://mirrors.o2switch.fr/batocera/x86_64/stable/last/batocera-x86_64-43-YYYYMMDD.img.gz"
-            # MD5_URL="${IMAGE_URL}.md5"
-
-            # BETA: derive MD5 URL from user-pasted URL — remove this block when going official
-            # MD5 disabled: skip mirror URL prompt when using local file
-            # if [ -z "${IMAGE_URL:-}" ]; then
-            #   echo ""
-            #   echo "  Paste the mirror URL for this image (ends with .img.gz or .img.gz.md5):"
-            #   echo ""
-            #   printf "  URL: "
-            #   read -r IMAGE_URL
-            # fi
-            IMAGE_URL="${IMAGE_URL:-}"
-            sanitize_image_url
-            # END BETA
             return 0
             ;;
           2) ;; # fall through to URL prompt below
@@ -901,23 +929,25 @@ prompt_image_source() {
           i=$((i + 1))
         done
         box_empty
-        box_center "  ($((count + 1))) Enter download URL instead"
+        box_center "  ($((count + 1))) Download from official server instead"
         box_center "  ($((count + 2))) Cancel"
         box_hash
         echo ""
         read -r multi_choice
         if [ "$multi_choice" -ge 1 ] 2>/dev/null && [ "$multi_choice" -le "$count" ]; then
           IMAGE_PATH=$(echo "$IMAGE_CANDIDATES" | sed -n "${multi_choice}p")
-          # MD5 disabled: skip mirror URL prompt when using local file
-          # if [ -z "${IMAGE_URL:-}" ]; then
-          #   echo ""
-          #   echo "  Paste the mirror URL for this image (ends with .img.gz or .img.gz.md5):"
-          #   echo ""
-          #   printf "  URL: "
-          #   read -r IMAGE_URL
-          # fi
-          IMAGE_URL="${IMAGE_URL:-}"
-          sanitize_image_url
+          if [ ! -f "${IMAGE_PATH}.md5" ]; then
+            echo ""
+            err_box "MD5 checksum file not found: ${IMAGE_PATH}.md5"
+            box_center "Transfer the .md5 file from the Batocera download page"
+            box_center "to the same location, then scan again."
+            box_empty
+            box_hash
+            echo ""
+            echo "  Press ENTER to scan again..."
+            read -r
+            continue
+          fi
           return 0
         elif [ "$multi_choice" -eq $((count + 1)) ]; then
           : # fall through to URL prompt
@@ -932,28 +962,29 @@ prompt_image_source() {
       box_empty
       box_center "No Batocera x86_64 image found on /userdata or USB drives."
       box_empty
-      box_center "HOW TO GET THE IMAGE ONTO THIS MACHINE"
+      box_center "You can download it directly or transfer manually."
       box_empty
-      box_center "STEP 1 - Download the X11 Batocera image on your PC/Mac."
-      box_center "  Use the mirror link provided to you."
+      box_center "OPTION A - Let this script download it (recommended)"
+      box_center "  Select (2) below. ~4 GB download."
       box_empty
-      box_center "STEP 2 - Transfer it to this machine (pick one):"
+      box_center "OPTION B - Transfer the image yourself"
       box_empty
-      box_center "  Windows: WinSCP  ->  wiki.batocera.org/winscp"
-      box_center "    Connect: batocera.local | root | linux"
-      box_center "    Drop file into: /userdata/"
+      box_center "  1. Download the X11 Batocera image AND its .md5 file."
+      box_center "     (Both are available on the Batocera download page.)"
       box_empty
-      box_center "  Mac/Linux: open a second terminal and run:"
-      box_center "    scp FILE root@batocera.local:/userdata/"
+      box_center "  2. Transfer both files to this machine:"
+      box_center "     Windows: WinSCP  ->  wiki.batocera.org/winscp"
+      box_center "       Connect: batocera.local | root | linux"
+      box_center "       Drop files into: /userdata/"
+      box_center "     Mac/Linux: scp FILES root@batocera.local:/userdata/"
+      box_center "     USB Drive: copy files to USB, plug into this machine"
       box_empty
-      box_center "  USB Drive: copy file to USB, plug into this machine"
-      box_empty
-      box_center "STEP 3 - Come back here and select (1) to scan again."
+      box_center "  3. Come back here and select (1) to scan again."
       box_empty
       box_hash
       echo ""
       echo "  (1) Scan again — I have transferred the file"
-      echo "  (2) Paste download URL — script will download directly"
+      echo "  (2) Download from official server"
       echo "  (3) Exit"
       echo ""
       read -r nf_choice
@@ -964,39 +995,19 @@ prompt_image_source() {
       esac
     fi
 
-    # URL prompt (beta: paste URL; official: hardcoded)
-    # OFFICIAL: hardcoded URL — uncomment when v43 ships publicly
-    # IMAGE_URL="https://mirrors.o2switch.fr/batocera/x86_64/stable/last/batocera-x86_64-43-YYYYMMDD.img.gz"
-
-    # BETA: user pastes URL at runtime — remove this block when going official
-    box_hash
-    box_center "X11 Beta Image — Enter Download URL"
-    box_hash
-    box_empty
-    box_center "Paste the direct download link for the X11 beta image."
-    box_center "Use the .img.gz link, NOT the .md5 link."
-    box_center "(Right-click the file on the mirror -> Copy Link Address)"
-    box_empty
-    echo ""
-    printf "  URL: "
-    read -r IMAGE_URL
-    # END BETA
-
-    sanitize_image_url
+    IMAGE_URL="$X11_IMAGE_URL"
 
     box_hash
-    box_center "Confirm Download"
+    box_center "Download X11 Batocera Image"
     box_hash
     box_empty
     box_center "Image: ${IMAGE_URL}"
-    box_center "MD5:   ${MD5_URL}"
-    box_center "       (derived automatically from image URL)"
+    box_center "MD5:   ${X11_MD5_URL}"
     box_empty
     box_hash
     echo ""
     echo "  (1) Yes, download"
-    echo "  (2) Enter a different URL"
-    echo "  (3) Exit"
+    echo "  (2) Cancel"
     echo ""
     read -r confirm_dl
     case "$confirm_dl" in
@@ -1005,7 +1016,6 @@ prompt_image_source() {
         download_x11_image
         return 0
         ;;
-      2) continue ;;
       *) exit 0 ;;
     esac
   done
@@ -1359,6 +1369,7 @@ CRTENTRY
 }
 
 prompt_cleanup_source_image() {
+  local md5_file="${IMAGE_PATH}.md5"
   box_hash
   box_center "Cleanup"
   box_hash
@@ -1366,6 +1377,9 @@ prompt_cleanup_source_image() {
   local fsize
   fsize=$(du -h "$IMAGE_PATH" 2>/dev/null | cut -f1)
   box_center "Source image: ${IMAGE_PATH}  (${fsize})"
+  if [ -f "$md5_file" ]; then
+    box_center "MD5 file:     ${md5_file}"
+  fi
   box_empty
   box_center "The boot files have been extracted successfully."
   box_center "The source image is no longer needed."
@@ -1380,7 +1394,8 @@ prompt_cleanup_source_image() {
   read -r cleanup_choice
   if [ "$cleanup_choice" = "1" ]; then
     rm -f "$IMAGE_PATH"
-    ok_box "Source image deleted."
+    rm -f "$md5_file"
+    ok_box "Source image and MD5 file deleted."
   else
     box_center "Source image kept at: ${IMAGE_PATH}"
   fi
@@ -1398,7 +1413,17 @@ run_phase1() {
   prompt_image_source
 
   # Step 2: Validate checksum
-  # validate_md5
+  if ! validate_md5; then
+    echo ""
+    echo "  (1) Continue without MD5 verification"
+    echo "  (2) Abort"
+    echo ""
+    read -r md5_choice
+    case "$md5_choice" in
+      1) echo "  Proceeding without checksum verification..." ;;
+      *) exit 1 ;;
+    esac
+  fi
 
   # Step 3: Check disk space
   check_disk_space

--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher.sh
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher.sh
@@ -211,10 +211,13 @@ main() {
         sleep 2
         
         if is_dualboot_system; then
-            # Dual-boot: full shutdown required for any cross-kernel transition.
-            # Warm reboots leave stale DRM/KMS state in GPU hardware registers,
-            # causing black screens when the new kernel initializes its display stack.
-            poweroff
+            # Dual-boot: immediate kernel power-off for cross-kernel
+            # transition.  Normal poweroff can hang on some GPUs;
+            # SysRq 'o' is reliable across all hardware.
+            batocera-save-overlay 2>/dev/null || true
+            sync
+            sync
+            echo o > /proc/sysrq-trigger
         else
             reboot
         fi

--- a/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-combo
+++ b/userdata/system/Batocera-CRT-Script/extra/media_keys/crt-mode-switch-combo
@@ -362,9 +362,11 @@ sleep 2
 # Use absolute paths: user services / Popen often have PATH without /sbin, so bare
 # "poweroff" can be missing and exit silently before the kernel acts.
 if is_dualboot_system; then
-  _crt_script_log "shutdown: dual-boot (/boot/crt/linux + initrd-crt.gz) -> /sbin/poweroff"
+  _crt_script_log "shutdown: dual-boot (/boot/crt/linux + initrd-crt.gz) -> SysRq power-off"
+  batocera-save-overlay 2>/dev/null || true
   sync 2>/dev/null || true
-  /sbin/poweroff 2>/dev/null || /sbin/shutdown -P -h now 2>/dev/null || _crt_script_log "ERROR: poweroff failed (check root / PATH)"
+  sync 2>/dev/null || true
+  echo o > /proc/sysrq-trigger
 else
   _crt_script_log "shutdown: single-boot -> /sbin/reboot"
   sync 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **Official v43 download**: replaces beta user-paste URL flow with hardcoded official X11 image endpoint
- **Local MD5 validation**: checksum verified from a local `.md5` file (downloaded alongside the image from o2switch mirror, or transferred manually), no inline URL derivation
- **SysRq shutdown fix**: dual-boot mode switching uses `echo o > /proc/sysrq-trigger` instead of `poweroff`, fixing ACPI power-off hang on desktop PCs and improving shutdown speed on Steam Deck

## What changed

### Batocera-CRT-Script-v43.sh (Phase 1 X11 install)

- **`X11_IMAGE_URL`** constant: Katapult CDN (`sour-silent-prune.6fcff5d8.katapult.cloud`).
- **`X11_MD5_URL`** constant: o2switch mirror (`mirrors.o2switch.fr`). Separate host from image.
- **`download_x11_image()`**: downloads both the image and its `.md5` file (from `X11_MD5_URL`).
- **`validate_md5()`**: reads checksum from local `${IMAGE_PATH}.md5` only. No remote URL fetching. Returns error if `.md5` file is missing.
- **`prompt_image_source()`**: for local files, requires `.md5` file to be present; guides user to transfer both files. Download path uses hardcoded `X11_IMAGE_URL`.
- **`run_phase1()`**: `validate_md5` re-enabled with fallback prompt ("Continue without MD5 verification?").
- **`prompt_cleanup_source_image()`**: displays and deletes `.md5` file alongside the image.
- **Beta prompt removed**: "Paste download URL" flow replaced with clean confirmation dialog showing both URLs.
- **Menu text updated**: "Enter download URL" changed to "Download from official server" everywhere.
- **"Not found" instructions**: rewritten to lead with direct download as Option A, manual transfer (with both image + .md5 files) as Option B. Download size corrected to ~4 GB.

### mode_switcher.sh (HD/CRT Mode Switcher UI)

- **Dual-boot shutdown**: replaced `poweroff` with `batocera-save-overlay` + double `sync` + `echo o > /proc/sysrq-trigger`.
- Normal `poweroff` hangs on some desktop PCs (X11 GPU driver blocks ACPI S5 state). SysRq 'o' forces immediate kernel power-off, bypassing the stuck driver.
- Data safety preserved: overlay is saved and buffers are flushed before the trigger.
- Single-boot path unchanged (`reboot`).

### crt-mode-switch-combo (Blind chord: SELECT+START+L1+L2)

- Same SysRq power-off change applied to the blind CRT-to-HD chord for consistency.

## How was this tested

### X11 Image Download + MD5 Validation
- **Downloaded directly from official server**: https://youtu.be/9RbhngYhCk0
- **Manually transferred to /userdata/ via SMB (FileZilla)**: https://youtu.be/wBMKV1cuVOY

Both runs completed Phase 1: image acquisition, MD5 validation, boot file extraction, initrd patch, syslinux config, overlay deploy, cleanup, and shutdown.

### SysRq Shutdown (Mode Switcher)
- **Desktop PC (ASRock B660M Pro RS, Intel 12th gen + AMD dGPU)**: 3 full HD<->CRT round trips, instant power-off every time. Previously hung requiring force power-off.
- **Steam Deck (Valve Jupiter LCD)**: 2 full HD<->CRT round trips via mode_switcher UI. Shuts off noticeably faster than before (~instant vs ~20 seconds with `poweroff`).

### SysRq Shutdown (Blind Chord)
- **Steam Deck**: CRT-to-HD blind chord tested, instant power-off.
- Note: Steam Deck must have power adapter **unplugged** for SysRq power-off to complete (charger keeps system in a wake-capable state).