### PR TITLE
fix: backport batocera-steam-update fix for v43 (PR #15670)

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -1443,7 +1443,14 @@ run_phase1() {
   # Step 8: Offer to delete source image
   prompt_cleanup_source_image
 
-  # Step 9: Write phase flag for Phase 2
+  # Step 9: Install batocera-steam-update fix (v43 only, PR #15670)
+  # Saves to Wayland overlay so the fix persists in HD mode.
+  # Phase 2 installs the same file into the CRT overlay.
+  cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update /usr/bin/batocera-steam-update 2>/dev/null && \
+    chmod 755 /usr/bin/batocera-steam-update 2>/dev/null || true
+  batocera-save-overlay 2>/dev/null || true
+
+  # Step 10: Write phase flag for Phase 2
   mkdir -p "$(dirname "$PHASE_FLAG")"
   echo "2" > "$PHASE_FLAG"
 
@@ -4847,9 +4854,10 @@ case $Version_of_batocera in
 		cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/get_monitorRange  /usr/bin/get_monitorRange
 		chmod 755 /usr/bin/get_monitorRange
 
-                #only for V41. Xemu from V42 to fixe a Mesa isse with AAMD
-                #cp -r /userdata/system/Batocera-CRT-Script/UsrBin_configs/xemu_v41/usr /	
-		#chmod 755 /usr/bin/xemu
+		# v43 only: batocera-steam-update fix from batocera-linux PR #15670.
+		# Remove when v44 ships with this fix upstream.
+		cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update /usr/bin/batocera-steam-update
+		chmod 755 /usr/bin/batocera-steam-update
 
 	;;
 

--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher_modules/03_backup_restore.sh
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher_modules/03_backup_restore.sh
@@ -909,6 +909,12 @@ VNC_SCRIPT_EOF
                 [ -f "/userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.svg" ] && \
                     cp /userdata/system/Batocera-CRT-Script/Geometry_modeline/CRT.svg /boot/crt_theme_assets/CRT.svg 2>/dev/null || true
 
+                # Copy Steam fix to /boot so boot-custom.sh can access it
+                # (S00bootcustom runs before S11share mounts /userdata)
+                [ -f "/userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update" ] && \
+                    cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update /boot/crt_theme_assets/batocera-steam-update 2>/dev/null && \
+                    chmod 755 /boot/crt_theme_assets/batocera-steam-update 2>/dev/null || true
+
                 if [ -f "/userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/x11vnc" ]; then
                     chmod 755 /userdata/system/Batocera-CRT-Script/install-vnc_server_batocera/x11vnc 2>/dev/null || true
                     cat > /boot/crt_theme_assets/vnc << 'VNC_DUALBOOT_EOF'
@@ -1012,8 +1018,18 @@ install_vnc() {
   cp /boot/crt_theme_assets/vnc /usr/bin/vnc 2>/dev/null && chmod 755 /usr/bin/vnc 2>/dev/null || true
 }
 
+install_steam_fix() {
+  # v43 only: batocera-steam-update fix from batocera-linux PR #15670.
+  # Remove when v44 ships with this fix upstream.
+  # Source is on /boot/ (not /userdata/) because S00bootcustom runs before S11share.
+  local SRC="/boot/crt_theme_assets/batocera-steam-update"
+  [ -f "$SRC" ] && cp "$SRC" /usr/bin/batocera-steam-update 2>/dev/null && chmod 755 /usr/bin/batocera-steam-update 2>/dev/null || true
+}
+
 main() {
   [ "$1" = "start" ] || return 0
+
+  install_steam_fix
 
   local CMD="$(cat /proc/cmdline 2>/dev/null)"
   if echo "$CMD" | grep -q 'BOOT_IMAGE=/crt/'; then
@@ -1065,6 +1081,12 @@ VNC_SCRIPT_EOF
                 chmod 755 /boot/crt_theme_assets/vnc 2>/dev/null || true
             fi
             
+            # Copy Steam fix to /boot so boot-custom.sh can access it
+            # (S00bootcustom runs before S11share mounts /userdata)
+            [ -f "/userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update" ] && \
+                cp /userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update /boot/crt_theme_assets/batocera-steam-update 2>/dev/null && \
+                chmod 755 /boot/crt_theme_assets/batocera-steam-update 2>/dev/null || true
+
             # Create boot-custom.sh that copies from /boot to /usr/share/ (no /userdata dependency)
             cat > /boot/boot-custom.sh << 'BOOTCUSTOM_EOF'
 #!/bin/bash
@@ -1072,9 +1094,19 @@ VNC_SCRIPT_EOF
 # Runs via /etc/init.d/S00bootcustom very early in boot (before EmulationStation)
 # Files are pre-copied to /boot during mode switch, so /userdata mount timing doesn't matter
 
+install_steam_fix() {
+  # v43 only: batocera-steam-update fix from batocera-linux PR #15670.
+  # Remove when v44 ships with this fix upstream.
+  # Source is on /boot/ (not /userdata/) because S00bootcustom runs before S11share.
+  local SRC="/boot/crt_theme_assets/batocera-steam-update"
+  [ -f "$SRC" ] && cp "$SRC" /usr/bin/batocera-steam-update 2>/dev/null && chmod 755 /usr/bin/batocera-steam-update 2>/dev/null || true
+}
+
 main() {
   # Run only on start
   [ "$1" = "start" ] || return 0
+
+  install_steam_fix
   
   # Only copy in HD mode (check if overlay exists - if not, we're in HD mode)
   if [ ! -f "/boot/boot/overlay" ]; then

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/Steam_fix_v43/batocera-steam-update
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+log="/userdata/system/logs/steam.log"
+
+es_add_game_begin() {
+    echo "<gameList>" > /tmp/batocera-steam-update.tmp || return 1
+}
+
+es_add_game_end() {
+    ES_SERVER="http://127.0.0.1:1234"
+
+    echo "</gameList>" >> /tmp/batocera-steam-update.tmp || return 1
+    curl -s -X POST -H "Content-type: application/x-www-form-urlencoded" -H "Accept: text/plain" "${ES_SERVER}/addgames/steam" -d "@/tmp/batocera-steam-update.tmp" > /dev/null || return 1
+}
+
+es_add_game() {
+    GAME_BASENAME=$1
+    GAME_NAME=$2
+    GAME_IMAGE=$3
+
+    (cat <<EOF
+<game>
+  <path>./${GAME_BASENAME}</path>
+  <name>${GAME_NAME}</name>
+  <desc></desc>
+  <rating></rating>
+  <releasedate></releasedate>
+  <developer></developer>
+  <publisher></publisher>
+  <genre></genre>
+  <players></players>
+  <image>${GAME_IMAGE}</image>
+  <manual></manual>
+  <video></video>
+</game>
+EOF
+) >> /tmp/batocera-steam-update.tmp || return 1
+}
+
+# Start the game list
+es_add_game_begin || exit 1
+
+# create steam application app
+steam_file="/userdata/roms/steam/Steam.steam"
+mkdir -p /userdata/roms/steam || exit 1
+if [ ! -f "$steam_file" ]; then
+    echo "com.valvesoftware.Steam" > "$steam_file"
+    echo "Steam.steam file created successfully." >> $log
+    mkdir -p /userdata/roms/steam/images
+    # take flatpak logo
+    steam_png="/userdata/roms/flatpak/images/Valve Corporation.png"
+    if [ -f "$steam_png" ]; then
+        cp "$steam_png" /userdata/roms/steam/images/Steam.png
+        echo "Steam logo copied successfully." >> $log
+    else
+        echo "Steam logo not found, could not copy." >> $log
+    fi
+    es_add_game "Steam.steam" "Steam" "./images/Steam.png"
+    echo "Steam app added to game list." >> $log
+fi
+
+# Steam may put .desktop files in different locations depending on Flatpak/Steam version:
+# - newer: $HOME/Desktop (via XDG Desktop portal)
+# - older: $HOME/.var/app/com.valvesoftware.Steam/.local/share/applications
+steam_search_dirs=()
+for dir in \
+    "/userdata/saves/flatpak/data/Desktop" \
+    "/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/applications"; do
+    [ -d "$dir" ] && steam_search_dirs+=("$dir")
+done
+
+if [ ${#steam_search_dirs[@]} -eq 0 ]; then
+    echo "Steam applications directory not found" >> $log
+else
+    # Define a blacklist of words to check in game names
+    BLACKLIST=(
+        "Runtime"
+        "Proton"
+        "SDK"
+        "Dedicated"
+        "Workshop"
+        "Big Picture"
+        "Source"
+        "Linux Runtime"
+        "Redistributables"
+        "Desktop Mode"
+    )
+
+    # Function to check if a game name contains any blacklisted word
+    contains_blacklisted_word() {
+        local game_name="$1"
+        for word in "${BLACKLIST[@]}"; do
+            if [[ "$game_name" == *"$word"* ]]; then
+                return 0  # Found in blacklist, should be ignored
+            fi
+        done
+        return 1  # Not found, can be added
+    }
+
+    # Find and process applications
+    find "${steam_search_dirs[@]}" -name "*.desktop" | (
+        N=0
+        while read STEAMAPP; do
+            if grep -qE '^[ ]*Categories[ ]*=.*Game.*$' "${STEAMAPP}"; then  # Check if it's a game
+                BASEAPP=$(basename "${STEAMAPP}" | sed -e 's/\.desktop$//')
+
+                if contains_blacklisted_word "$BASEAPP"; then
+                    echo "Skipping blacklisted entry: ${BASEAPP}" >> $log
+                    continue
+                fi
+
+                if ! test -e "/userdata/roms/steam/${BASEAPP}.steam"; then
+                    echo "Adding ${BASEAPP}"
+                    GAMEID=$(grep -E '^Exec=' "${STEAMAPP}" | sed -e 's/Exec=//' -e 's/[ ]*steam[ ]*//' | head -1)
+
+                    # Add image
+                    ICON=$(grep -E "^Icon=" "${STEAMAPP}" | sed -e 's/^Icon=steam_icon_//')_logo.png
+                    IMGFILE="/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/appcache/librarycache/${ICON}"
+                    IMGARG=
+                    if test -e "${IMGFILE}"; then
+                        IMGARG="./images/${BASEAPP}.png"
+                        mkdir -p "/userdata/roms/steam/images" || return 1
+                        cp "${IMGFILE}" "/userdata/roms/steam/${IMGARG}" || return 1
+                    fi
+
+                    # Add game
+                    echo "${GAMEID}" > "/userdata/roms/steam/${BASEAPP}.steam" || return 1
+
+                    # Add game in EmulationStation
+                    if ! es_add_game "${BASEAPP}.steam" "${BASEAPP}" "${IMGARG}"; then
+                        echo "Adding game in EmulationStation failed" >&2
+                        return 1
+                    fi
+                    let N++
+                fi
+            fi
+        done
+        echo "${N} games added to the list." >> $log
+    )
+fi
+
+# End the game list
+es_add_game_end || exit 1
+
+exit 0


### PR DESCRIPTION
## Summary

- Backports the `batocera-steam-update` fix from [batocera-linux PR #15670](https://github.com/batocera-linux/batocera.linux/pull/15670) for v43. The stock v43 script fails to add installed Steam games to the EmulationStation game list.
- Phase 2 installs the fixed file to `/usr/bin/` (persists in the CRT overlay for X11-exclusive users).
- For mode switcher users (both dual-boot Wayland/X11 and single-boot X11), `boot-custom.sh` copies the fix from `/boot/crt_theme_assets/` to `/usr/bin/` on every boot. This is necessary because `S00bootcustom` runs before `S11share` mounts `/userdata`, and overlay wipes during mode switches can remove the file.
- v43 only: remove when v44 ships with this fix upstream.

## Files changed

| File | Change |
|------|--------|
| `UsrBin_configs/Steam_fix_v43/batocera-steam-update` | Fixed script from upstream PR #15670 |
| `Batocera-CRT-Script-v43.sh` | Phase 1 + Phase 2 install to `/usr/bin/` |
| `mode_switcher_modules/03_backup_restore.sh` | Copy to `/boot/` + `install_steam_fix()` in both dual-boot and single-boot `boot-custom.sh` heredocs |

## Test plan

- [x] Dual-boot: Phase 1 (Wayland) -> Phase 2 (X11) -> CRT->HD round trip -> verify 4810-byte fix in `/usr/bin/` on Wayland
- [x] Dual-boot: verify `boot-custom.sh` on `/boot/` reads from `/boot/crt_theme_assets/`
- [x] X11-exclusive: Phase 2 install -> verify fix persists across reboots
- [x] Steam game install -> game appears in ES game list