### PR TITLE
SwitchRes modeline cleanup more reliable v43

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
@@ -14,7 +14,6 @@ mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
 
 # --- Clean up previous switchres modeline - start ---
-# NOTE (v42 behaviour that actually works on your stack):
 # You can only reliably --delmode/--rmmode *after* switching away from the old SR mode.
 # So here we ONLY remember the previous mode; cleanup happens later (post-switch).
 STATE_FILE="/tmp/switchres-last-resolution-state"

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
@@ -1,5 +1,5 @@
 #!/bin/bash
-# batocera-resolution (patched)
+# batocera-resolution
 #
 # Key changes:
 # - If /etc/switchres.ini has monitor=custom, we DO NOT touch monitor nor crt_range0..9.

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_MYZAR_ZFEbHVUE-MultiScreen
@@ -14,23 +14,16 @@ mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
 
 # --- Clean up previous switchres modeline - start ---
+# NOTE (v42 behaviour that actually works on your stack):
+# You can only reliably --delmode/--rmmode *after* switching away from the old SR mode.
+# So here we ONLY remember the previous mode; cleanup happens later (post-switch).
 STATE_FILE="/tmp/switchres-last-resolution-state"
+XRANDR_CMD="xrandr -display :0.0"
+
+PREV_OUTPUT=""
+PREV_MODE=""
 if [ -f "$STATE_FILE" ]; then
-    read -r LAST_OUTPUT LAST_MODE < "$STATE_FILE"
-    CURRENT_MODE=$(xrandr --verbose | awk -v out="$LAST_OUTPUT" '
-        $0 ~ "^"out {found=1}
-        found && / connected/ {found=0}
-        found && /[0-9]+x[0-9]+/ && /\*/ {print $1; exit}
-    ')
-    if [ "$CURRENT_MODE" = "$LAST_MODE" ]; then
-        echo "[batocera-resolution] Skipping deletion of $LAST_MODE because it is currently active on $LAST_OUTPUT" >> "$log"
-    elif xrandr | grep -q "$LAST_MODE"; then
-        echo "[batocera-resolution] Deleting modeline $LAST_MODE from output $LAST_OUTPUT" >> "$log"
-        xrandr --delmode "$LAST_OUTPUT" "$LAST_MODE"
-    else
-        echo "[batocera-resolution] Previous modeline $LAST_MODE not found, skipping deletion" >> "$log"
-    fi
-    rm -f "$STATE_FILE"
+    read -r PREV_OUTPUT PREV_MODE < "$STATE_FILE"
 fi
 # --- Clean up previous switchres modeline - end ---
 
@@ -400,13 +393,27 @@ case "${ACTION}" in
 
         game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
 
-        # Log newly generated modeline for future cleanup
-        NEW_MODE=$(xrandr | grep 'SR-1_' | awk '{print $1}' | tail -n1)
+        # Log newly generated modeline for future cleanup (v42-style)
+        NEW_MODE=$(xrandr -display :0.0 | grep 'SR-1_' | awk '{print $1}' | tail -n1)
         if [ -n "$NEW_MODE" ] && [ -n "$OUTPUT" ]; then
             echo "$OUTPUT $NEW_MODE" > /tmp/switchres-last-resolution-state
             echo "[batocera-resolution] Stored modeline state: $NEW_MODE on $OUTPUT" >> "$log"
         fi
 
+
+        # --- Post-switch cleanup of previous SR mode (v42-style, but done at the right time) ---
+        # If we had a previous SR mode recorded, remove it now that we've switched away.
+        if [ -n "$PREV_OUTPUT" ] && [ -n "$PREV_MODE" ] && [ "$PREV_MODE" != "$NEW_MODE" ]; then
+            if $XRANDR_CMD | grep -q " ${PREV_MODE}[[:space:]]"; then
+                echo "[batocera-resolution] Post-switch: --delmode $PREV_MODE from $PREV_OUTPUT" >> "$log"
+                $XRANDR_CMD --delmode "$PREV_OUTPUT" "$PREV_MODE" 2>>"$log" || true
+            fi
+            echo "[batocera-resolution] Post-switch: --rmmode $PREV_MODE" >> "$log"
+            $XRANDR_CMD --rmmode "$PREV_MODE" 2>>"$log" || true
+        fi
+        # Clear state file only after we've attempted cleanup. (New state will be written above.)
+        # This avoids getting stuck on an "active" mode that couldn't be removed yet.
+        # --- End post-switch cleanup ---
         # Restore monitor and dotclock_min
         sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"
         sed -i "s/.*dotclock_min        .*/    dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
@@ -14,23 +14,16 @@ mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
 
 # --- Clean up previous switchres modeline - start ---
+# NOTE (v42 behaviour that actually works on your stack):
+# You can only reliably --delmode/--rmmode *after* switching away from the old SR mode.
+# So here we ONLY remember the previous mode; cleanup happens later (post-switch).
 STATE_FILE="/tmp/switchres-last-resolution-state"
+XRANDR_CMD="xrandr -display :0.0"
+
+PREV_OUTPUT=""
+PREV_MODE=""
 if [ -f "$STATE_FILE" ]; then
-    read -r LAST_OUTPUT LAST_MODE < "$STATE_FILE"
-    CURRENT_MODE=$(xrandr --verbose | awk -v out="$LAST_OUTPUT" '
-        $0 ~ "^"out {found=1}
-        found && / connected/ {found=0}
-        found && /[0-9]+x[0-9]+/ && /\*/ {print $1; exit}
-    ')
-    if [ "$CURRENT_MODE" = "$LAST_MODE" ]; then
-        echo "[batocera-resolution] Skipping deletion of $LAST_MODE because it is currently active on $LAST_OUTPUT" >> "$log"
-    elif xrandr | grep -q "$LAST_MODE"; then
-        echo "[batocera-resolution] Deleting modeline $LAST_MODE from output $LAST_OUTPUT" >> "$log"
-        xrandr --delmode "$LAST_OUTPUT" "$LAST_MODE"
-    else
-        echo "[batocera-resolution] Previous modeline $LAST_MODE not found, skipping deletion" >> "$log"
-    fi
-    rm -f "$STATE_FILE"
+    read -r PREV_OUTPUT PREV_MODE < "$STATE_FILE"
 fi
 # --- Clean up previous switchres modeline - end ---
 
@@ -400,13 +393,27 @@ case "${ACTION}" in
 
         game_switchres=$(switchres ${WIDTH} ${HEIGHT} ${PARTHZ} -s -k -f ${WIDTH}x${HEIGHT}@${PARTHZ} -g "${H_size}:${H_shift}:${V_shift}")
 
-        # Log newly generated modeline for future cleanup
-        NEW_MODE=$(xrandr | grep 'SR-1_' | awk '{print $1}' | tail -n1)
+        # Log newly generated modeline for future cleanup (v42-style)
+        NEW_MODE=$(xrandr -display :0.0 | grep 'SR-1_' | awk '{print $1}' | tail -n1)
         if [ -n "$NEW_MODE" ] && [ -n "$OUTPUT" ]; then
             echo "$OUTPUT $NEW_MODE" > /tmp/switchres-last-resolution-state
             echo "[batocera-resolution] Stored modeline state: $NEW_MODE on $OUTPUT" >> "$log"
         fi
 
+
+        # --- Post-switch cleanup of previous SR mode (v42-style, but done at the right time) ---
+        # If we had a previous SR mode recorded, remove it now that we've switched away.
+        if [ -n "$PREV_OUTPUT" ] && [ -n "$PREV_MODE" ] && [ "$PREV_MODE" != "$NEW_MODE" ]; then
+            if $XRANDR_CMD | grep -q " ${PREV_MODE}[[:space:]]"; then
+                echo "[batocera-resolution] Post-switch: --delmode $PREV_MODE from $PREV_OUTPUT" >> "$log"
+                $XRANDR_CMD --delmode "$PREV_OUTPUT" "$PREV_MODE" 2>>"$log" || true
+            fi
+            echo "[batocera-resolution] Post-switch: --rmmode $PREV_MODE" >> "$log"
+            $XRANDR_CMD --rmmode "$PREV_MODE" 2>>"$log" || true
+        fi
+        # Clear state file only after we've attempted cleanup. (New state will be written above.)
+        # This avoids getting stuck on an "active" mode that couldn't be removed yet.
+        # --- End post-switch cleanup ---
         # Restore monitor and dotclock_min
         sed -i "s/.*monitor        .*/    monitor              $Monitor_custom/" "$Switchres_file"
         sed -i "s/.*dotclock_min        .*/    dotclock_min              $DOTCLOCK_MIN/" "$Switchres_file"

--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/batocera-resolution-v43_Nvidia_driver_MYZAR_ZFEbHVUE-MultiScreen
@@ -1,5 +1,5 @@
 #!/bin/bash
-# batocera-resolution (patched)
+# batocera-resolution
 #
 # Key changes:
 # - If /etc/switchres.ini has monitor=custom, we DO NOT touch monitor nor crt_range0..9.
@@ -14,7 +14,6 @@ mpvlog="/userdata/system/logs/mpv.log"
 BOOTCONF="/boot/batocera-boot.conf"
 
 # --- Clean up previous switchres modeline - start ---
-# NOTE (v42 behaviour that actually works on your stack):
 # You can only reliably --delmode/--rmmode *after* switching away from the old SR mode.
 # So here we ONLY remember the previous mode; cleanup happens later (post-switch).
 STATE_FILE="/tmp/switchres-last-resolution-state"


### PR DESCRIPTION
This PR makes SwitchRes modeline cleanup more reliable on some CRT/Xorg stacks.

Instead of trying to `xrandr --delmode/--rmmode` the previous `SR-1_*` mode *before* switching (can fail when the mode is still active), we now:

- read and keep the previous SR mode from `/tmp/switchres-last-resolution-state`
- generate/apply the new SR mode
- remove the previous SR mode **after the switch** (post-switch cleanup)

Also standardizes SR mode detection/cleanup to use `xrandr -display :0.0`.

Applied to both `batocera-resolution` variants (normal + nvidia).