### PR TITLE
fix: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force Unix line endings for all shell scripts
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- Adds a `.gitattributes` file that forces `eol=lf` on all `*.sh` files
- Prevents Windows-style CRLF line endings from slipping in via contributors' editors
- Complements the manual CRLF fix from PR #416

## Context
CRLF line endings in shell scripts caused "file not found" errors on Batocera. PR #416 fixed the existing files, but without `.gitattributes`, new contributions could reintroduce the problem. This ensures git normalizes line endings on checkout and commit.