### PR TITLE
fix(installer): enforce version guard in v42 and v43 scripts

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v42.sh
@@ -1426,6 +1426,16 @@ case "${version_Batocera}" in
     ;;
 esac
 
+if [ "$Version_of_batocera" != "v42" ]; then
+  box_hash
+  box_center "${RED}WRONG BATOCERA VERSION${NOCOLOR}"
+  box_center "This script requires Batocera v42."
+  box_center "Detected: ${version_Batocera}"
+  box_center "Please use the correct script for your version."
+  box_hash
+  exit 1
+fi
+
 # (Optional) temporary compatibility for any stray references to the old misspelled var.
 # You can remove this after you’re sure nothing reads "verion".
 verion="${VERSION_BATOCERA_NUM}"

--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -2323,7 +2323,7 @@ NOCOLOR=${NOCOLOR:-"\033[0m"}
 # -------------------- Banner box --------------------
 printf "%s\n" "$border"
 empty_line
-center "BATOCERA CRT SCRIPT — 15 kHz / 25 kHz / 31 kHz for Batocera v42"
+center "BATOCERA CRT SCRIPT — 15 kHz / 25 kHz / 31 kHz for Batocera v43"
 empty_line
 center "Use at your own risk. The authors are not responsible for damage or data loss."
 empty_line
@@ -2406,11 +2406,6 @@ version_Batocera="$(batocera-es-swissknife --version 2>/dev/null || echo unknown
 echo "Version batocera = ${version_Batocera}" >> /userdata/system/logs/BUILD_15KHz_Batocera.log
 
 case "${version_Batocera}" in
-  42*)
-    echo "Version 42"
-    Version_of_batocera="v42"
-    VERSION_BATOCERA_NUM=42
-    ;;
   43*)
     echo "Version 43"
     Version_of_batocera="v43"
@@ -2422,6 +2417,16 @@ case "${version_Batocera}" in
     VERSION_BATOCERA_NUM=0
     ;;
 esac
+
+if [ "$Version_of_batocera" != "v43" ]; then
+  box_hash
+  box_center "${RED}WRONG BATOCERA VERSION${NOCOLOR}"
+  box_center "This script requires Batocera v43."
+  box_center "Detected: ${version_Batocera}"
+  box_center "Please use the correct script for your version."
+  box_hash
+  exit 1
+fi
 
 # (Optional) temporary compatibility for any stray references to the old misspelled var.
 # You can remove this after you’re sure nothing reads "verion".


### PR DESCRIPTION
## Summary

Both scripts detected the running Batocera version but never aborted on a mismatch. The v43 script had a stray `42*` case arm that caused it to silently accept and configure a v42 system. The v42 script let v43 fall through to `unknown` but continued executing rather than exiting. This adds hard stops to both scripts so a user running the wrong script gets a clear error instead of a partially-applied configuration.

## Changes

- `Batocera-CRT-Script-v43.sh`: remove the `42*` case arm from the version detection block; add a post-`case` exit guard that prints a boxed error and exits with code 1 if the detected version is not `v43`
- `Batocera-CRT-Script-v42.sh`: add the same post-`case` exit guard for any non-`v42` system
- `Batocera-CRT-Script-v43.sh`: fix banner copy-paste that read "for Batocera v42" instead of "for Batocera v43"

## Test plan
- <img width="1009" height="563" alt="v42-crt-v43" src="https://github.com/user-attachments/assets/c4a2d7c4-8976-4833-a4a7-b4838c359279" />

- <img width="1009" height="459" alt="v43-crt-v42" src="https://github.com/user-attachments/assets/67918f12-b2ab-463d-b1c9-476bc9dc80bf" />

- <img width="1011" height="347" alt="v43" src="https://github.com/user-attachments/assets/fb8b7b4e-95b6-48ea-ba95-53282c67c87b" />

- [x] Run v43 script on a v42 system: should print boxed "WRONG BATOCERA VERSION" error and exit immediately
- [x] Run v42 script on a v43 system: should print boxed "WRONG BATOCERA VERSION" error and exit immediately
- [x] Run v43 script on a v43 system: should proceed normally past the version check
- [x] Run v42 script on a v42 system: should proceed normally past the version check
- [x] Confirm banner in v43 script now reads "for Batocera v43"

## Notes

The exit guard fires before any system changes are made (the version check happens before GPU detection), so there is no partial-apply risk on a wrong-version run.