### PR TITLE
fix(v43): restore menu mode and ES layout on libretro gameStop

### DIFF
--- a/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v42
+++ b/userdata/system/Batocera-CRT-Script/System_configs/First_script/first_script.sh-generic-v42
@@ -88,13 +88,39 @@ case "$ACTION" in
   ;;
 
   gameStop)
-    # Restore Rotation to EmulationStation and Resolution
+    # Restore rotation and the Boot menu modeline after Switchres games.
+    # Plain xrandr --mode "WxH" can pick the wrong 641x480 variant after RA
+    # switchres; use the Boot_ key from batocera.conf (same path as ES boot).
     log "gameStop: Restoring EmulationStation Rotation + Resolution"
     log "xrandr rotation emulationstation: [display_ES_rotation]"
     xrandr -display :0.0 -o [display_ES_rotation]
+
+    MENU_MODE="$(batocera-settings-get global.videomode 2>/dev/null || true)"
+    if [ -z "$MENU_MODE" ] || [ "$MENU_MODE" = "default" ] || [ "$MENU_MODE" = "auto" ]; then
+      MENU_MODE="$(batocera-settings-get es.resolution 2>/dev/null || true)"
+    fi
+
     log "xrandr display output: [card_display]"
-    log "EmulationStation Resolution: [es_resolution]"
-    xrandr -display :0.0 --output [card_display] --mode "[es_resolution]"
+    log "EmulationStation mode: ${MENU_MODE:-[es_resolution]}"
+
+    if [ -n "$MENU_MODE" ] && [ "$MENU_MODE" != "default" ] && [ "$MENU_MODE" != "auto" ]; then
+      # Match ES boot: defineMode adds the Boot_ modeline, then setMode_CVT selects it.
+      batocera-resolution --screen "[card_display]" defineMode "$MENU_MODE" 2>/dev/null || true
+      if batocera-resolution --screen "[card_display]" setMode_CVT "$MENU_MODE"; then
+        log "Restored menu mode via batocera-resolution setMode_CVT: $MENU_MODE"
+        # X mode is correct but ES keeps a stale layout after Switchres games.
+        if [ "${3:-}" = "libretro" ]; then
+          log "Refreshing EmulationStation (libretro Switchres exit)"
+          batocera-es-swissknife --restart >/dev/null 2>&1 || true
+        fi
+      else
+        log "setMode_CVT failed; falling back to xrandr --mode [es_resolution]"
+        xrandr -display :0.0 --output [card_display] --mode "[es_resolution]"
+      fi
+    else
+      log "No menu mode in settings; falling back to xrandr --mode [es_resolution]"
+      xrandr -display :0.0 --output [card_display] --mode "[es_resolution]"
+    fi
     # No need to unset vblank_mode — it's per-process
   ;;
 
@@ -105,4 +131,5 @@ esac
 
 log "Done."
 [ "$DEBUG" -eq 1 ] && set +x
+true
 


### PR DESCRIPTION
## Summary

After quitting a libretro game with `crt_switch_resolution=4`, Switchres leaves X on a game modeline and does not restore the Boot menu mode. The stock `first_script.sh` gameStop hook used plain `xrandr --mode WxH`, which could select the wrong modeline variant (especially on NTSC 641x480). Even when X mode was restored correctly, EmulationStation kept a stale layout until manually restarted.

This PR updates the `first_script.sh-generic-v42` template deployed by the v43 installer to restore the menu using the same path as ES boot (`defineMode` + `setMode_CVT` with `global.videomode`), then restart ES on libretro gameStop.

## Changes

- `System_configs/First_script/first_script.sh-generic-v42`
  - gameStop reads `global.videomode` / `es.resolution` at runtime
  - Calls `defineMode` then `setMode_CVT` on the CRT output
  - Restarts ES via `batocera-es-swissknife --restart` for libretro exits
  - Falls back to xrandr only if `setMode_CVT` fails
  - Adds trailing `true` so gameStop logs `status=0` (not a false failure from `set +x`)

## Test plan

- [x] Tested on Batocera v43 (`2026/04/29`) with R9 280X, DVI-I-1, NTSC 641x480.60.00074, `crt_switch_resolution=4`
- [x] SNES libretro (240p Suite): ES scaling correct after quit without manual `--restart`
- [x] Log shows `setMode_CVT`, `Refreshing EmulationStation`, `EXIT action=gameStop status=0`
- [x] VanGogh APU PAL dev box (769x576): no regression on libretro game exit

## Notes

- MAME/Groovy and standalone paths unchanged (no ES restart on those gameStop paths).
- Re-run CRT installer or redeploy from template after geometry changes that rewrite `first_script.sh`.