### PR TITLE
Improves formatting of the CRT Script settings written to batocera.conf

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
+++ b/userdata/system/Batocera-CRT-Script/Batocera_ALLINONE/Batocera-CRT-Script-v43.sh
@@ -5488,6 +5488,28 @@ chmod 644 $file
 #######################################################################################
 file_BatoceraConf="/userdata/system/batocera.conf"
 
+append_crt_script_settings_start() {
+	{
+		echo "###################################################"
+		echo "## CRT Script Settings Start"
+		echo "###################################################"
+		echo "## ES Settings, See wiki page on how to center EmulationStation"
+	} >> "$file_BatoceraConf"
+}
+
+append_fbneo_tate_settings() {
+	{
+		echo "###################################################"
+		echo "##  FBNEO CORE TATE SETTINGS"
+		echo "###################################################"
+		echo "fbneo.video_allow_rotate=off"
+		echo "###################################################"
+		echo "## CRT Script Settings End"
+		echo "###################################################"
+	} >> "$file_BatoceraConf"
+}
+
+
 # Steps 4-5: Write CRT videomode/videooutput to batocera.conf and pre-populate CRT backup
 # Remove any existing lines first to avoid duplicates (factory conf may have these set)
 if [ -n "$_crt_boot_mode" ]; then
@@ -5519,7 +5541,7 @@ if [ -n "$_crt_boot_mode" ]; then
     sed -i '/^es\.resolution=/d' "$file_BatoceraConf"
     echo "es.resolution=$_crt_boot_mode" >> "$file_BatoceraConf"
 fi
-echo "## ES Settings, See wiki page on how to center EmulationStation" 			>> "$file_BatoceraConf"
+append_crt_script_settings_start
 
 if [ "$ES_rotation" == "NORMAL" ] || [ "$ES_rotation" == "INVERTED" ]; then
 	es_customsargs="es.customsargs=--screensize "$H_RES_EDID" "$V_RES_EDID" --screenoffset 00 00"
@@ -5865,7 +5887,7 @@ if [ $es_rotation_choice -eq 1 ]; then
 			echo "Problems of rotation_choice"
 		;;
 	esac
-	echo "fbneo.video_allow_rotate=off"						>> "$file_BatoceraConf"
+	append_fbneo_tate_settings
 fi
 
 if [ $es_rotation_choice -eq 2 ]; then
@@ -5887,7 +5909,7 @@ if [ $es_rotation_choice -eq 2 ]; then
 			echo "Problems of rotation_choice"
 		;;
 	esac
-	echo "fbneo.video_allow_rotate=off"						>> "$file_BatoceraConf"
+	append_fbneo_tate_settings
 fi
 
 if [ $es_rotation_choice -eq 3 ]; then
@@ -5909,7 +5931,7 @@ if [ $es_rotation_choice -eq 3 ]; then
 			echo "Problems of rotation_choice"
 		;;
 	esac
-	echo "fbneo.video_allow_rotate=off"						 >> "$file_BatoceraConf"
+	append_fbneo_tate_settings
 fi
 
 if [ $es_rotation_choice -eq 4 ]; then
@@ -5931,7 +5953,7 @@ if [ $es_rotation_choice -eq 4 ]; then
 				echo "Problems of rotation_choice"
 			;;
 		esac
-	echo "fbneo.video_allow_rotate=off" 						>> "$file_BatoceraConf"
+	append_fbneo_tate_settings
 fi
 chmod 755 "$file_BatoceraConf"
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR improves the formatting of the CRT Script settings written to `batocera.conf`.

Instead of writing the ES settings marker directly as a standalone line, the script now wraps the CRT Script configuration section with a clear start marker:

```ini
###################################################
## CRT Script Settings Start
###################################################
## ES Settings, See wiki page on how to center EmulationStation
```

The FBNeo TATE setting block now also closes the CRT Script settings section:

```ini
###################################################
##  FBNEO CORE TATE SETTINGS
###################################################
fbneo.video_allow_rotate=off
###################################################
## CRT Script Settings End
###################################################
```

## Why

This makes the generated `batocera.conf` easier to read and easier to identify as CRT Script managed settings.

The original ES marker line is kept unchanged:

```ini
## ES Settings, See wiki page on how to center EmulationStation
```

This preserves compatibility with existing script logic that searches for that line, for example:

```bash
LINE_NO=$(sed -n '/## ES Settings, See wiki page on how to center EmulationStation/{=;q;}' /userdata/system/batocera.conf.bak)
```

## Technical notes

- Added helper functions for writing the CRT Script settings start block and FBNeo TATE block.
- Replaced repeated single-line `echo` calls with the helper functions.
- Keeps the existing append flow intact.
- Avoids changing the existing ES marker text, so current `sed` lookup logic continues to work.
- Verified with `bash -n` to ensure the script still parses correctly.