### PR TITLE
Fix `changeMode_cvt()`

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/Configgen/VideoMode.py-v43_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/Configgen/VideoMode.py-v43_ZFEbHVUE
@@ -39,20 +39,30 @@ def changeMode(videomode: str) -> None:
                 time.sleep(1)
 
 def changeMode_cvt(videomode: str) -> None:
-    if checkModeExists(videomode):
-        cmd = ["batocera-resolution", "setMode_CVT", videomode]
-        _logger.debug("setVideoMode(%s): %s", videomode, cmd)
-        max_tries = 2  # maximum number of tries to set the mode
-        for i in range(max_tries):
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                _logger.debug(result.stdout.strip())
-                return
-            except subprocess.CalledProcessError as e:
-                _logger.error("Error setting video mode: %s", e.stderr)
-                if i == max_tries - 1:
-                    raise BatoceraException("Error setting video mode") from e
-                time.sleep(1)
+    if not videomode:
+        _logger.error("changeMode_cvt: invalid empty video mode")
+        return
+
+    if not checkModeExists(videomode):
+        _logger.warning(
+            "changeMode_cvt: mode %s not found in listModes, trying setMode_CVT anyway",
+            videomode
+        )
+
+    cmd = ["batocera-resolution", "setMode_CVT", videomode]
+    _logger.debug("changeMode_cvt setVideoMode(%s): %s", videomode, cmd)
+
+    max_tries = 2
+    for i in range(max_tries):
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            _logger.debug("changeMode_cvt %s", result.stdout.strip())
+            return
+        except subprocess.CalledProcessError as e:
+            _logger.error("Error setting video mode: %s", e.stderr)
+            if i == max_tries - 1:
+                raise BatoceraException("Error setting video mode") from e
+            time.sleep(1)
 
 def getCurrentMode() -> str:  # noqa: RET503
     proc = subprocess.Popen(["batocera-resolution currentMode"], stdout=subprocess.PIPE, shell=True)


### PR DESCRIPTION
Fix `changeMode_cvt()` so it does not block valid EDID/menu mode restores when `checkModeExists()` fails.

`batocera-resolution currentMode` may return an xrandr-derived mode such as `769x576.50.00`, while `batocera-resolution listModes` contains the full `videomodes.conf` token such as `769x576.50.00075`.

These describe the same practical restore target, but `checkModeExists()` requires an exact token match and rejects `769x576.50.00`.

Before this change, `changeMode_cvt()` would skip the restore completely. After this change, it logs a warning but still tries `batocera-resolution setMode_CVT`, which correctly restores the EDID/menu mode using xrandr, for example:

`xrandr --output DVI-I-1 --mode 769x576 --rate 50.00`

This is especially important when exiting RetroArch/GroovyMAME with SwitchRes API enabled, because the API handles its own temporary `SR-1_...` modes and Batocera should return to the original EDID/menu mode, not block the restore because of a token-format mismatch.