### PR TITLE
Update CRT Geometry Tool

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/geometry.sh
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/geometry.sh
@@ -1,16 +1,35 @@
 #!/bin/bash
 
-# Define the directory path
-log_dir="/userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/"
+# Define the backup directory path
+# Keep Geometry Tool backups together with the main Batocera CRT Script backup folder.
+backup_root="/userdata/Batocera-CRT-Script-Backup"
+log_dir="${backup_root}/Geometry_Tool_Backup/"
+old_log_dir="/userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/"
 
-# Define the path to the log file
-log_file="${log_dir}backup.file"
+# If an older Geometry Tool backup exists, migrate it to the new backup location.
+# This keeps Restore Files working for users who already ran an older version of the tool.
+if [ ! -d "$log_dir" ] && [ -d "$old_log_dir" ]; then
+    mkdir -p "$log_dir"
+    cp -a "${old_log_dir}." "$log_dir" 2>/dev/null
+fi
 
 # Check if the directory exists
 if [ ! -d "$log_dir" ]; then
     # Create the directory if it doesn't exist
     mkdir -p "$log_dir"
 fi
+
+# Define the path to the log file
+log_file="${log_dir}backup.file"
+
+# Define key backup file paths used to verify that backups are complete
+switchres_backup="${log_dir}etc/switchres.ini.backup"
+nvidia_backup="${log_dir}userdata/system/99-nvidia.conf.backup"
+syslinux_main_backup="${log_dir}boot/boot/syslinux.cfg.backup"
+syslinux_sub_backup="${log_dir}boot/boot/syslinux/syslinux.cfg.backup"
+syslinux_efi_backup="${log_dir}boot/EFI/syslinux.cfg.backup"
+syslinux_efi_boot_backup="${log_dir}boot/EFI/BOOT/syslinux.cfg.backup"
+syslinux_efi_batocera_backup="${log_dir}boot/EFI/batocera/syslinux.cfg.backup"
 
 # Informational dialog box about using the Geometry tool
 geometry_tool_warning() {
@@ -49,12 +68,12 @@ saving_overlay_file() {
 }
 
 # Check if both files exist before performing the backup
-if [ -f "/userdata/system/99-nvidia.conf" ] && [ -e "$log_file" ]; then
-    echo "Both 99-nvidia.conf and log file exist. Skipping backup."
+if [ -f "/userdata/system/99-nvidia.conf" ] && [ -e "$log_file" ] && [ -f "$switchres_backup" ] && [ -f "$nvidia_backup" ]; then
+    echo "99-nvidia.conf, switchres.ini backup, and log file exist. Skipping backup."
 elif [ -f "/userdata/system/99-nvidia.conf" ]; then
     # Backup 99-nvidia.conf and switchres.ini files 
-    install -D -m 0755 /etc/switchres.ini "$log_dir/etc/switchres.ini.backup"
-    install -D -m 0644 /userdata/system/99-nvidia.conf "$log_dir/userdata/system/99-nvidia.conf.backup"
+    install -D -m 0755 /etc/switchres.ini "$switchres_backup"
+    install -D -m 0644 /userdata/system/99-nvidia.conf "$nvidia_backup"
     # Create the log file
     touch "$log_file"
 else
@@ -62,18 +81,18 @@ else
     making_boot_writable
     
     # Check if the log file exists
-    if [ -e "$log_file" ]; then
+    if [ -e "$log_file" ] && [ -f "$switchres_backup" ] && [ -f "$syslinux_main_backup" ] && [ -f "$syslinux_sub_backup" ]; then
         echo "Syslinux files and switchres.ini backup already performed."
     else
         echo "Backing up syslinux and switchres.ini files..."
 
         # Backup syslinux.cfg files and switchres.ini
-        install -D -m 0755 /etc/switchres.ini "$log_dir/etc/switchres.ini.backup"
-        install -D -m 0755 /boot/boot/syslinux.cfg "$log_dir/boot/boot/syslinux.cfg.backup"
-        install -D -m 0755 /boot/boot/syslinux/syslinux.cfg "$log_dir/boot/boot/syslinux.cfg.backup"
-        install -D -m 0755 /boot/EFI/syslinux.cfg "$log_dir/boot/EFI/syslinux.cfg.backup"
-        install -D -m 0755 /boot/EFI/BOOT/syslinux.cfg "$log_dir/boot/EFI/BOOT/syslinux.cfg.backup"
-        install -D -m 0755 /boot/EFI/batocera/syslinux.cfg "$log_dir/boot/EFI/batocera/syslinux.cfg.backup"
+        install -D -m 0755 /etc/switchres.ini "$switchres_backup"
+        install -D -m 0755 /boot/boot/syslinux.cfg "$syslinux_main_backup"
+        install -D -m 0755 /boot/boot/syslinux/syslinux.cfg "$syslinux_sub_backup"
+        install -D -m 0755 /boot/EFI/syslinux.cfg "$syslinux_efi_backup"
+        install -D -m 0755 /boot/EFI/BOOT/syslinux.cfg "$syslinux_efi_boot_backup"
+        install -D -m 0755 /boot/EFI/batocera/syslinux.cfg "$syslinux_efi_batocera_backup"
 
         # Create the log file
         touch "$log_file"
@@ -98,13 +117,13 @@ dialog --title "Monitor Information" \
 clear
 
 # Extract refresh rate from Boot Resolution
-refresh_rate=$(echo "$boot_resolution" | grep -oP '@\K\d+')
+refresh_rate=$(echo "$boot_resolution" | sed -n 's/.*@\([0-9][0-9]*\).*/\1/p')
 
 # Check if the Boot Resolution is disallowed
 disallowed_resolutions=("800x600@60" "1027x576@50" "1027x576@25" "1024x576@25" "1024x768@25" "1024x768@50")
 if [[ " ${disallowed_resolutions[@]} " =~ " $boot_resolution " ]]; then
     dialog --title "Unsupported Resolution" \
-           --yesno "Your boot resolution is set for $boot_resolution which is not supported.\nWould you like to run the geometry script for the following resolutions?\n\n640x480@60 (Default Recommended)\n320x240@60\n768x576@50" 12 60
+           --yesno "Your boot resolution is set for $boot_resolution which is not supported.\nWould you like to run the geometry script using 640x480@60?\n\n640x480@60 (Default Recommended)" 10 60
     case $? in
         0)
             ;;
@@ -123,10 +142,13 @@ restore_syslinux_files() {
         # Restoring 99-nvidia.conf and switchres.ini files if 99-nvidia.conf exists
         echo "Restoring 99-nvidia.conf and switchres.ini files..."
 
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/etc/switchres.ini.backup /etc/switchres.ini
-        install -D -m 0644 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/userdata/system/99-nvidia.conf.backup /userdata/system/99-nvidia.conf
+        install -D -m 0755 "$switchres_backup" /etc/switchres.ini
+        install -D -m 0644 "$nvidia_backup" /userdata/system/99-nvidia.conf
 
         echo "99-nvidia.conf & switchres.ini successfully restored."
+
+        # Save overlay so restored /etc/switchres.ini persists after reboot
+        saving_overlay_file
 
         # Reboot or exit
         dialog --title "Reboot or Exit" \
@@ -147,14 +169,17 @@ restore_syslinux_files() {
         # Restore syslinux files if 99-nvidia.conf does not exist
         echo "Restoring syslinux files and switchres.ini..."
 
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/etc/switchres.ini.backup /etc/switchres.ini
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/boot/boot/syslinux.cfg.backup /boot/boot/syslinux.cfg
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/boot/boot/syslinux.cfg.backup /boot/boot/syslinux/syslinux.cfg 
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/boot/EFI/syslinux.cfg.backup /boot/EFI/syslinux.cfg
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/boot/EFI/BOOT/syslinux.cfg.backup /boot/EFI/BOOT/syslinux.cfg
-        install -D -m 0755 /userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/boot/EFI/batocera/syslinux.cfg.backup /boot/EFI/batocera/syslinux.cfg
+        install -D -m 0755 "$switchres_backup" /etc/switchres.ini
+        install -D -m 0755 "$syslinux_main_backup" /boot/boot/syslinux.cfg
+        install -D -m 0755 "$syslinux_sub_backup" /boot/boot/syslinux/syslinux.cfg 
+        install -D -m 0755 "$syslinux_efi_backup" /boot/EFI/syslinux.cfg
+        install -D -m 0755 "$syslinux_efi_boot_backup" /boot/EFI/BOOT/syslinux.cfg
+        install -D -m 0755 "$syslinux_efi_batocera_backup" /boot/EFI/batocera/syslinux.cfg
 
         echo "Syslinux files restored successfully."
+
+        # Save overlay so restored /etc/switchres.ini persists after reboot
+        saving_overlay_file
 
         # Reboot or exit
         dialog --title "Reboot or Exit" \
@@ -172,32 +197,6 @@ restore_syslinux_files() {
 }
 
 
-# Set a variable to control the visibility of the "Custom Resolution" option
-show_custom_resolution=true
-
-# Function to handle custom resolution input
-handle_custom_resolution() {
-    # Prompt for custom resolution
-    resolution_input=$(dialog --title "Custom Resolution" \
-                              --clear \
-                              --inputbox "Enter your custom resolution in the format 'WIDTHxHEIGHT@REFRESH_RATE, Example 1024x768x60':" 10 60 \
-                              3>&1 1>&2 2>&3)
-    # Check if the user pressed cancel
-    if [ -z "$resolution_input" ]; then
-        return 1  # Signal to continue resolution selection
-    fi
-    # Extract width, height, and refresh rate from the input
-    width=$(echo $resolution_input | cut -d'x' -f1)
-    height=$(echo $resolution_input | cut -d'x' -f2 | cut -d'@' -f1)
-    refresh_rate=$(echo $resolution_input | cut -d'@' -f2)
-    
-    # Adjust width component
-    adjusted_width=$((width + 1))
-    width=$adjusted_width
-    
-    return 0  # Signal to break out of the loop
-}
-
 # Dialog to select resolution
 while true; do
     choice=$(dialog --title "Resolution Selection" \
@@ -205,9 +204,6 @@ while true; do
                     --nocancel \
                     --menu "Choose your resolution" 20 80 10 \
                     "640x480@60" "640x480 60Hz (Default Recommended)" \
-                    "320x240@60" "320x240 60Hz" \
-                    "768x576@50" "768x576 50Hz" \
-                    $(if $show_custom_resolution; then echo '"Custom Resolution" "Enter a custom resolution"'; fi) \
                     "Restore Files" "Revert changes and restore" \
                     "Quit" "Exit back to ES" \
                     3>&1 1>&2 2>&3)
@@ -218,31 +214,6 @@ while true; do
             height=480
             refresh_rate=60
             break
-            ;;
-        "320x240@60")
-            width=320
-            height=240
-            refresh_rate=60
-            break
-            ;;
-        "768x576@50")
-            width=768
-            height=576
-            refresh_rate=50
-            break
-            ;;
-        "Custom Resolution")
-            if $show_custom_resolution; then
-                handle_custom_resolution
-                if [ $? -eq 0 ]; then
-                    break
-                else
-                    continue  # Go back to resolution selection
-                fi
-            else
-                echo "Custom resolution option is disabled."
-                continue  # Go back to resolution selection
-            fi
             ;;
         "Restore Files")
             restore_syslinux_files  # Call the function to restore syslinux files
@@ -261,6 +232,7 @@ done
 
 # Run the Python script with the selected resolution and refresh rate
 output=$(/usr/bin/geometry "$width" "$height" "$refresh_rate")
+geometry_status=$?
 
 # Check if the output contains "Aborted!"
 if [[ $output == *"Aborted!"* ]]; then
@@ -286,6 +258,14 @@ if [ -z "$crt_range_value" ]; then
         }')"
 fi
 
+# Stop if geometry did not produce a valid crt_range.
+# This prevents writing an empty crt_range0 line to switchres.ini.
+if [ $geometry_status -ne 0 ] || [ -z "$crt_range_value" ]; then
+    dialog --title "Geometry Error" \
+           --msgbox "The geometry tool did not return a valid crt_range. No changes were written to switchres.ini." 10 60
+    clear_terminal
+fi
+
 swini="/etc/switchres.ini"
 [ -f "$swini" ] || touch "$swini"
 
@@ -303,7 +283,7 @@ BEGIN {
     }
     # Replace the first crt_range0 line with the new range
     if (!seen_crt0 && $0 ~ /^[[:space:]]*crt_range0[[:space:]]+/) {
-        print "    crt_range0                " newrange;
+        print "    crt_range0              " newrange;
         seen_crt0=1;
         next;
     }
@@ -312,7 +292,7 @@ BEGIN {
 }
 END {
     if (!seen_monitor) print "     monitor                   custom";
-    if (!seen_crt0)   print "    crt_range0                " newrange;
+    if (!seen_crt0)   print "    crt_range0              " newrange;
 }' "$swini" > "${swini}.tmp" && mv "${swini}.tmp" "$swini"
 
 dialog --title "Success" \
@@ -329,15 +309,28 @@ if [ -f "/userdata/system/99-nvidia.conf" ]; then
     IFS="@ " read -r RESOLUTION FREQ <<< "$resolution"
     IFS="x" read -r H_RES_EDID V_RES_EDID <<< "$RESOLUTION"
 
-    # Adjust width component
-    adjusted_width=$(( ${H_RES_EDID%%x} + 1 )) # Extract width, add 1
-    H_RES_EDID="$adjusted_width"x"$V_RES_EDID"
+    if [ -z "$H_RES_EDID" ] || [ -z "$V_RES_EDID" ] || [ -z "$FREQ" ]; then
+        dialog --title "Boot Resolution Error" \
+               --msgbox "Could not read a valid Boot Resolution from /userdata/system/logs/BootRes.log. No EDID or NVIDIA modeline changes were made." 10 70
+        clear_terminal
+    fi
 
-    # Run switchres and capture its output
-    switchres_output=$(switchres "$H_RES_EDID" "$V_RES_EDID" "$FREQ" -f "$H_RES_EDID"x"$V_RES_EDID"@"$FREQ" -i switchres.ini -c | grep "Modeline")
+    # Adjust width component only.
+    # Keep width and height as separate values for switchres.
+    H_RES_EDID=$(( H_RES_EDID + 1 ))
 
-    # Remove leading whitespace
-    switchres_output=$(echo "$switchres_output" | sed 's/^[ \t]*//')
+    # Run switchres and capture the first generated Modeline.
+    # Use /etc/switchres.ini explicitly so the newly written crt_range is used.
+    switchres_output=$(switchres "$H_RES_EDID" "$V_RES_EDID" "$FREQ" -f "${H_RES_EDID}x${V_RES_EDID}@${FREQ}" -i "$swini" -c | awk '/Modeline/ { sub(/^[[:space:]]*Switchres:[[:space:]]*/, ""); print; exit }')
+
+    # Remove leading whitespace and strip SwitchRes suffix from the mode name, if present.
+    switchres_output=$(printf "%s\n" "$switchres_output" | sed 's/^[[:space:]]*//; s/\(Modeline[[:space:]]*"[^_"]*\)_[^"]*"/\1"/')
+
+    if [ -z "$switchres_output" ]; then
+        dialog --title "SwitchRes Error" \
+               --msgbox "SwitchRes did not return a Modeline for the NVIDIA configuration. 99-nvidia.conf was not modified." 10 60
+        clear_terminal
+    fi
 
     # Prompt the user if they want to edit the existing 99-nvidia.conf file
     dialog --title "99-nvidia.conf Found" \
@@ -345,16 +338,20 @@ if [ -f "/userdata/system/99-nvidia.conf" ]; then
     response=$?
     case $response in
         0)  # User selected Yes, so proceed with editing
-            # Replace the existing Modeline in the file
-            sed -i "s/Modeline\s*\"[0-9]*x[0-9]*\".*/$switchres_output/" /userdata/system/99-nvidia.conf
-            # Add sed command to replace "Switchres: Modeline " with "Modeline "
-            sed -i 's/Switchres: Modeline "/Modeline "/' /userdata/system/99-nvidia.conf
-			# Add sed command to remove everything between _ and " including the symbol _
-#			sed -i 's/\([^_]*\)_[^"]*/\1"/' /userdata/system/99-nvidia.conf
-			sed -i 's/\(Modeline\s*"[^_]*\)_[^"]*"/\1"/' /userdata/system/99-nvidia.conf
+            # Replace the first existing Modeline safely.
+            # If no Modeline exists, append the generated one.
+            tmp_nvidia_conf=$(mktemp /tmp/99-nvidia.conf.XXXXXX)
+            awk -v newline="$switchres_output" '
+                /^[[:space:]]*Modeline[[:space:]]*"/ && !done { print newline; done=1; next }
+                { print }
+                END { if (!done) print newline }
+            ' /userdata/system/99-nvidia.conf > "$tmp_nvidia_conf" && mv "$tmp_nvidia_conf" /userdata/system/99-nvidia.conf
 
 			dialog --title "99-nvidia.conf Updated" \
-                   --msgbox "99-nvidia.conf updated successfully. Please reboot to apply the changes." 10 40
+                   --msgbox "99-nvidia.conf updated successfully. The overlay will now be saved so switchres.ini persists after reboot." 10 60
+
+            # Save overlay so /etc/switchres.ini persists after reboot on NVIDIA setups
+            saving_overlay_file
             ;;
         1)  # User selected No, so exit the script
             dialog --title "99-nvidia.conf Not Modified" \
@@ -381,15 +378,26 @@ else
     IFS="@ " read -r RESOLUTION FREQ <<< "$resolution"
     IFS="x" read -r H_RES_EDID V_RES_EDID <<< "$RESOLUTION"
 
-    # Adjust width component
-    adjusted_width=$(( ${H_RES_EDID%%x} + 1 )) # Extract width, add 1
-    H_RES_EDID="$adjusted_width"x"$V_RES_EDID"
+    if [ -z "$H_RES_EDID" ] || [ -z "$V_RES_EDID" ] || [ -z "$FREQ" ]; then
+        dialog --title "Boot Resolution Error" \
+               --msgbox "Could not read a valid Boot Resolution from /userdata/system/logs/BootRes.log. No EDID or NVIDIA modeline changes were made." 10 70
+        clear_terminal
+    fi
 
-    # Generate the EDID file using switchres
-    switchres "$H_RES_EDID" "$V_RES_EDID" "$FREQ" -f "$H_RES_EDID"x"$V_RES_EDID"@"$FREQ" -i switchres.ini -e
+    # Adjust width component only.
+    # Keep width and height as separate values for switchres.
+    H_RES_EDID=$(( H_RES_EDID + 1 ))
 
-    # Identify the generated EDID file in the current directory
-    edid_file=$(find . -maxdepth 1 -name "*.bin" -print -quit)
+    # Generate the EDID file using switchres in a clean temporary directory.
+    # This avoids accidentally reusing an old .bin file from the current directory.
+    edid_workdir=$(mktemp -d /tmp/geometry-edid.XXXXXX)
+    (
+        cd "$edid_workdir" || exit 1
+        switchres "$H_RES_EDID" "$V_RES_EDID" "$FREQ" -f "${H_RES_EDID}x${V_RES_EDID}@${FREQ}" -i "$swini" -e
+    )
+
+    # Identify the generated EDID file
+    edid_file=$(find "$edid_workdir" -maxdepth 1 -name "*.bin" -print -quit)
 
     # If an EDID file is found, ask the user if they want to overwrite it
     if [ -f "$edid_file" ]; then
@@ -398,27 +406,32 @@ else
         response=$?
         case $response in
             0)  # User selected Yes, so proceed with overwriting
-                mv "$edid_file" custom.bin
+                mv "$edid_file" "$edid_workdir/custom.bin"
                 # Remove existing custom.bin if it exists
                 rm -f /lib/firmware/edid/custom.bin
-                mv custom.bin /lib/firmware/edid/
+                mv "$edid_workdir/custom.bin" /lib/firmware/edid/
+                rm -rf "$edid_workdir"
                 dialog --title "EDID File Generated" \
                        --msgbox "EDID file 'custom.bin' generated and moved to /lib/firmware/edid/" 10 40
                 ;;
             1)  # User selected No, so exit the script
+                rm -rf "$edid_workdir"
                 dialog --title "EDID File Not Overwritten" \
                        --msgbox "EDID file 'custom.bin' is not overwritten." 10 40
                 clear_terminal
                 ;;
             255)  # Dialog was canceled
+                rm -rf "$edid_workdir"
                 dialog --title "EDID File Not Overwritten" \
                        --msgbox "EDID file 'custom.bin' is not overwritten." 10 40
                 clear_terminal
                 ;;
         esac
     else
+        rm -rf "$edid_workdir"
         dialog --title "EDID File Not Found" \
-               --msgbox "Failed to find generated EDID file." 10 40
+               --msgbox "Failed to find generated EDID file. Syslinux EDID references were not changed." 10 60
+        clear_terminal
     fi
 
     # Define the file paths to update EDID references in syslinux configurations


### PR DESCRIPTION
## Summary

This PR cleans up and hardens the CRT Geometry Tool.

The main change is that the tool now only exposes `640x480@60` as the selectable geometry adjustment mode. The previous options for `320x240@60`, `768x576@50`, and custom resolutions have been removed.

This is intentional. The current `geometry.py` tool is not a general-purpose geometry editor for arbitrary resolutions. It passes the selected mode to SwitchRes, reads back the adjusted geometry, and then returns a final `crt_range` value. If unsuitable resolutions are exposed through the dialog, users can end up writing bad geometry values back into `switchres.ini`.

The safe intended workflow is to use the standard 640x480 / 480-line geometry reference mode.

## Changes

- Removed unsupported geometry tool menu options:
  - `320x240@60`
  - `768x576@50`
  - Custom Resolution

- Updated the unsupported-resolution warning dialog so it only offers:
  - `640x480@60`

- Removed the custom resolution input handler.

- Added validation so the script stops if `geometry.py` does not return a valid `Final crt_range`.
  - This prevents writing an empty or broken `crt_range0` line to `/etc/switchres.ini`.

- Fixed NVIDIA persistence:
  - The NVIDIA path now saves the overlay after updating geometry-related files.
  - This fixes a case where `/etc/switchres.ini` could be updated for the current session but not persist correctly after reboot.

- Fixed restore persistence:
  - Restoring backed-up files now also saves the overlay where needed.

- Moved Geometry Tool backups from:

  `/userdata/system/Batocera-CRT-Script/Geometry_modeline/backup/`

  to:

  `/userdata/Batocera-CRT-Script-Backup/Geometry_Tool_Backup/`

  This keeps geometry recovery files together with the main Batocera CRT Script backup structure instead of storing them inside the active script/system path.

- Added migration handling for existing users:
  - If old Geometry Tool backups exist in the previous backup path, they are copied into the new backup location automatically.
  - This keeps Restore Files working for users who already ran an older version of the tool.

- Fixed a syslinux restore path issue:
  - `/boot/boot/syslinux/syslinux.cfg` is now restored from its matching backup path instead of accidentally using the backup for `/boot/boot/syslinux.cfg`.

- Preserved the existing +1 width behavior used when generating non-NVIDIA/AMD EDID and NVIDIA modelines files:
  - For example, a `640x480` boot resolution is still generated as `641x480`.
  - This keeps the existing Batocera CRT Script workaround intact.

- Cleaned up the SwitchRes command construction while keeping the +1 width behavior:
  - Width and height are now kept as separate variables internally.
  - The generated forced mode is built clearly as `641x480@60`.

- Made NVIDIA modeline replacement more robust:
  - The script now replaces the first `Modeline` line more safely.
  - If no existing `Modeline` is found, the generated one is appended.

- Made EDID generation safer:
  - EDID generation is now done in a clean temporary directory.
  - This avoids accidentally reusing an old `.bin` file from the current working directory.

- Removed dependency on `grep -P` for better compatibility with minimal Batocera environments.


- Fixed `crt_range0` spacing when writing back to `switchres.ini`.
  - The script now preserves the expected SwitchRes formatting style.
  - This is a cosmetic cleanup only and does not change the generated CRT range values.

## Why only 640x480?

The Geometry Tool should not be treated as a general custom-resolution adjustment tool.

The underlying `geometry.py` wrapper takes a mode, launches SwitchRes/grid, reads the adjusted geometry from SwitchRes output, and then returns a final `crt_range`. It does not implement resolution-specific safety checks for arbitrary custom modes.

Because of that, exposing custom resolutions, 768x576, or other modes from the dialog can produce bad geometry values and write them back into `switchres.ini`.

Limiting the dialog to `640x480@60` makes the tool safer and keeps it focused on the intended 480-line geometry reference workflow.

## Notes about the +1 width behavior

The existing +1 width behavior has been kept on purpose.

When generating the NVIDIA modeline or EDID after the geometry adjustment, the script still adds +1 to the boot resolution width. For example:

`640x480` becomes `641x480`

This is not removed or changed by this PR. The command construction was only cleaned up so the width, height, and refresh rate are handled more clearly before calling SwitchRes.