### PR TITLE
Fix `changeMode_cvt()` restore path

### DIFF
--- a/userdata/system/Batocera-CRT-Script/UsrBin_configs/Configgen/VideoMode.py-v43_ZFEbHVUE
+++ b/userdata/system/Batocera-CRT-Script/UsrBin_configs/Configgen/VideoMode.py-v43_ZFEbHVUE
@@ -43,12 +43,6 @@ def changeMode_cvt(videomode: str) -> None:
         _logger.error("changeMode_cvt: invalid empty video mode")
         return
 
-    if not checkModeExists(videomode):
-        _logger.warning(
-            "changeMode_cvt: mode %s not found in listModes, trying setMode_CVT anyway",
-            videomode
-        )
-
     cmd = ["batocera-resolution", "setMode_CVT", videomode]
     _logger.debug("changeMode_cvt setVideoMode(%s): %s", videomode, cmd)
 


### PR DESCRIPTION
## Fix `changeMode_cvt()` restore path

### Summary

This PR simplifies `changeMode_cvt()` in `VideoMode.py`.

The function now calls:

    batocera-resolution setMode_CVT <mode>

directly, instead of first checking the mode with `checkModeExists()`.

### What changed

Before:

    changeMode_cvt()` called `checkModeExists(videomode)` first.
    If the mode was not found in `batocera-resolution listModes`, it logged a warning and then continued.

After:

    changeMode_cvt()` no longer calls `checkModeExists()`.
    It directly attempts to restore the mode using `batocera-resolution setMode_CVT`.

### Why

`changeMode_cvt()` is used as a restore path, and it may receive xrandr-derived EDID/menu modes such as:

    769x576.50.00
    641x480.60.00

These modes are valid for `batocera-resolution setMode_CVT`, but they may not exist as exact entries in `batocera-resolution listModes`.

Because of that, checking them with `checkModeExists()` is unnecessary and can create misleading log output.

### Result

The restore path is cleaner and more direct.

For example:

    batocera-resolution setMode_CVT 769x576.50.00

correctly resolves to:

    xrandr --output DVI-I-1 --mode 769x576 --rate 50.00

This keeps the emulator exit restore path focused on returning to the current EDID/menu mode without requiring an exact `videomodes.conf` token match.

### Scope

Only `changeMode_cvt()` was changed.

The normal `changeMode()` path is unchanged.