### PR TITLE
fix(mode-switcher): restore ES launch splash after CRT restore

### DIFF
--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/crt/mode_switcher.sh
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/crt/mode_switcher.sh
@@ -6,12 +6,6 @@
 # Wayland/HD mode: xterm -maximized lands on the wrong display when a CRT DAC
 # is plugged in. Fix: inject a temporary labwc window rule that pins xterm to
 # the primary video output, then clean up on exit.
-#
-# X11/CRT mode: ES renders a single splash frame via SDL then blocks in
-# system(), leaving that frame frozen in the DRM scanout buffer.  The fix is
-# es_settings.cfg HideWindow=true, which causes ES to fully deinit its window
-# before running the command — releasing the DRM plane so xterm owns the
-# display cleanly. The mode-switch backup/restore logic sets this automatically.
 
 ADDED_RULE=0
 RC="/userdata/system/.config/labwc/rc.xml"

--- a/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher_modules/03_backup_restore.sh
+++ b/userdata/system/Batocera-CRT-Script/Geometry_modeline/mode_switcher_modules/03_backup_restore.sh
@@ -1228,10 +1228,7 @@ BOOTCUSTOM_EOF
             echo "[$(date +"%H:%M:%S")]: No es_settings.cfg in HD Mode backup" >> "$LOG_FILE"
         fi
 
-        # Remove HideWindow in HD mode — it is only needed for CRT mode X11 script
-        # launches. In HD/Wayland mode the labwc window-rule shim handles output
-        # placement; leaving HideWindow set is harmless but removes the splash which
-        # is desirable to keep in HD mode for a polished experience.
+        # HideWindow disables ES launch splash artwork
         local _es_cfg="/userdata/system/configs/emulationstation/es_settings.cfg"
         if [ -f "$_es_cfg" ] && grep -q 'name="HideWindow"' "$_es_cfg" 2>/dev/null; then
             sed -i '/<bool name="HideWindow"/d' "$_es_cfg" 2>/dev/null || true
@@ -1384,22 +1381,12 @@ BOOTCUSTOM_EOF
             echo "[$(date +"%H:%M:%S")]: No es_settings.cfg in CRT Mode backup" >> "$LOG_FILE"
         fi
 
-        # Ensure HideWindow=true in CRT mode so ES fully deinits before launching
-        # shell-script "games" (mode switcher, geometry tool, etc.).  Without this,
-        # ES renders a frozen splash frame that occupies the DRM scanout buffer for
-        # the entire duration of the child process, blocking xterm from appearing.
+        # HideWindow disables ES launch splash artwork
         local _es_cfg="/userdata/system/configs/emulationstation/es_settings.cfg"
-        mkdir -p "/userdata/system/configs/emulationstation"
-        if [ -f "$_es_cfg" ]; then
-            if grep -q 'name="HideWindow"' "$_es_cfg" 2>/dev/null; then
-                sed -i 's/<bool name="HideWindow" value="[^"]*"/<bool name="HideWindow" value="true"/' "$_es_cfg" 2>/dev/null || true
-            else
-                sed -i 's|</config>|\t<bool name="HideWindow" value="true" />\n</config>|' "$_es_cfg" 2>/dev/null || true
-            fi
-        else
-            printf '<?xml version="1.0"?>\n<config>\n\t<bool name="HideWindow" value="true" />\n</config>\n' > "$_es_cfg"
+        if [ -f "$_es_cfg" ] && grep -q 'name="HideWindow"' "$_es_cfg" 2>/dev/null; then
+            sed -i '/<bool name="HideWindow"/d' "$_es_cfg" 2>/dev/null || true
+            echo "[$(date +"%H:%M:%S")]: Removed HideWindow from es_settings.cfg (CRT mode)" >> "$LOG_FILE"
         fi
-        echo "[$(date +"%H:%M:%S")]: Ensured HideWindow=true in es_settings.cfg (CRT mode)" >> "$LOG_FILE"
 
         # 3. RESTORE BOOT-CUSTOM.SH (Creates X11 configs on boot)
         if ! is_dualboot_system; then


### PR DESCRIPTION
## Summary

After switching from HD back to CRT via the mode switcher, game launch splash artwork disappeared (black screen until the emulator drew). CRT restore was injecting `HideWindow=true` into `es_settings.cfg`, which tells EmulationStation to skip the launch splash for every game. This change strips `HideWindow` on CRT and HD restore instead of forcing it on CRT.

## Changes

- `03_backup_restore.sh`: remove CRT restore block that injected `HideWindow=true`; strip `HideWindow` on both CRT and HD restore if present (covers older backups)
- `crt/mode_switcher.sh`: remove obsolete header comment about the HideWindow workaround

## Test plan

- [x] Removed `HideWindow` from `es_settings.cfg` on local CRT hardware; launch splash and mode switcher both work (artwork → zoom → xterm)
- [x] Community tester confirmed splash returns after fix; mode switcher still launches correctly
- [x] HD→CRT switch with patched `03_backup_restore.sh` no longer re-injects `HideWindow`
- [x] Tested on fresh Wayland X11 Dual Boot

## Notes

`HideWindow=true` was a prior workaround for xterm hidden behind ES DRM scanout on some v43/X11 setups. If anyone reports a blank mode switcher after this change, they can add `HideWindow=true` manually in `es_settings.cfg` on that hardware only.